### PR TITLE
Обновление меню и документации API

### DIFF
--- a/client/src/components/AdminSidebar.tsx
+++ b/client/src/components/AdminSidebar.tsx
@@ -30,6 +30,7 @@ interface SidebarItem {
   icon: React.ComponentType<{ className?: string }>;
   badge?: string;
   badgeVariant?: "default" | "secondary" | "destructive" | "outline";
+  locked?: boolean;
 }
 
 interface Stats {
@@ -64,6 +65,56 @@ export default function AdminSidebar() {
     return location === item.url;
   };
 
+  const getTestId = (item: SidebarItem) =>
+    `link-${item.title
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/ё/g, "е")}`;
+
+  const renderMenuButton = (item: SidebarItem) => {
+    const content = (
+      <>
+        <item.icon className="h-4 w-4" />
+        <span>{item.title}</span>
+        {item.locked ? (
+          <Badge variant="outline" className="ml-auto text-xs border-dashed text-muted-foreground">
+            PRO
+          </Badge>
+        ) : (
+          item.badge && (
+            <Badge variant={item.badgeVariant || "default"} className="ml-auto text-xs">
+              {item.badge}
+            </Badge>
+          )
+        )}
+      </>
+    );
+
+    if (item.locked) {
+      return (
+        <SidebarMenuButton
+          className="justify-start opacity-60 cursor-not-allowed"
+          disabled
+          tooltip="Доступно в платной версии"
+          data-testid={getTestId(item)}
+        >
+          {content}
+        </SidebarMenuButton>
+      );
+    }
+
+    return (
+      <SidebarMenuButton
+        asChild
+        isActive={isItemActive(item)}
+        className="justify-start"
+        data-testid={getTestId(item)}
+      >
+        <Link href={item.url}>{content}</Link>
+      </SidebarMenuButton>
+    );
+  };
+
   const menuItems: SidebarItem[] = [
     {
       title: "Поиск",
@@ -71,7 +122,7 @@ export default function AdminSidebar() {
       icon: Search,
     },
     {
-      title: "Сайты для краулинга", 
+      title: "Проекты",
       url: "/admin/sites",
       icon: Globe,
       badge: sites ? sites.length.toString() : "0",
@@ -87,20 +138,23 @@ export default function AdminSidebar() {
     {
       title: "Статистика краулинга",
       url: "/admin/stats",
-      icon: Activity
+      icon: Activity,
+      locked: true
     },
     {
       title: "Расписание",
       url: "/admin/schedule",
-      icon: Calendar
+      icon: Calendar,
+      locked: true
     },
     {
       title: "Вебхуки",
       url: "/admin/webhooks",
-      icon: Webhook
+      icon: Webhook,
+      locked: true
     },
     {
-      title: "API для Тильды",
+      title: "Документация API",
       url: "/admin/api",
       icon: BookOpen
     },
@@ -125,24 +179,7 @@ export default function AdminSidebar() {
             <SidebarMenu>
               {menuItems.slice(0, 2).map((item) => (
                 <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton
-                    asChild
-                    isActive={isItemActive(item)}
-                    data-testid={`link-${item.title.toLowerCase().replace(/\s+/g, '-')}`}
-                  >
-                    <Link href={item.url}>
-                      <item.icon className="h-4 w-4" />
-                      <span>{item.title}</span>
-                      {item.badge && (
-                        <Badge 
-                          variant={item.badgeVariant || "default"} 
-                          className="ml-auto text-xs"
-                        >
-                          {item.badge}
-                        </Badge>
-                      )}
-                    </Link>
-                  </SidebarMenuButton>
+                  {renderMenuButton(item)}
                 </SidebarMenuItem>
               ))}
             </SidebarMenu>
@@ -155,24 +192,7 @@ export default function AdminSidebar() {
             <SidebarMenu>
               {menuItems.slice(2, 6).map((item) => (
                 <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton
-                    asChild
-                    isActive={isItemActive(item)}
-                    data-testid={`link-${item.title.toLowerCase().replace(/\s+/g, '-').replace(/ё/g, 'е')}`}
-                  >
-                    <Link href={item.url}>
-                      <item.icon className="h-4 w-4" />
-                      <span>{item.title}</span>
-                      {item.badge && (
-                        <Badge 
-                          variant={item.badgeVariant || "default"} 
-                          className="ml-auto text-xs"
-                        >
-                          {item.badge}
-                        </Badge>
-                      )}
-                    </Link>
-                  </SidebarMenuButton>
+                  {renderMenuButton(item)}
                 </SidebarMenuItem>
               ))}
             </SidebarMenu>
@@ -185,24 +205,7 @@ export default function AdminSidebar() {
             <SidebarMenu>
               {menuItems.slice(6).map((item) => (
                 <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton
-                    asChild
-                    isActive={isItemActive(item)}
-                    data-testid={`link-${item.title.toLowerCase().replace(/\s+/g, '-')}`}
-                  >
-                    <Link href={item.url}>
-                      <item.icon className="h-4 w-4" />
-                      <span>{item.title}</span>
-                      {item.badge && (
-                        <Badge 
-                          variant={item.badgeVariant || "default"} 
-                          className="ml-auto text-xs"
-                        >
-                          {item.badge}
-                        </Badge>
-                      )}
-                    </Link>
-                  </SidebarMenuButton>
+                  {renderMenuButton(item)}
                 </SidebarMenuItem>
               ))}
             </SidebarMenu>

--- a/client/src/pages/TildaApiPage.tsx
+++ b/client/src/pages/TildaApiPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
@@ -7,6 +8,16 @@ import { Copy, ExternalLink, Search, Globe, Code2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export default function TildaApiPage() {
+  const sections = [
+    {
+      id: "tilda",
+      title: "Tilda",
+      description: "Готовая интеграция для сайтов на Tilda.",
+      icon: Globe,
+    },
+  ];
+  const [activeSection, setActiveSection] = useState(sections[0].id);
+
   const currentDomain =
     typeof window !== "undefined" ? window.location.origin : "https://ваш-домен.replit.dev";
   const apiEndpoint = `${currentDomain}/api`;
@@ -399,14 +410,53 @@ export default function TildaApiPage() {
       <div className="mb-8">
         <h1 className="text-3xl font-bold mb-2 flex items-center gap-2">
           <Code2 className="h-8 w-8" />
-          API для интеграции с Тильдой
+          Документация API
         </h1>
         <p className="text-lg text-muted-foreground">
-          Подключите поисковый движок к вашему сайту на Тильде для обеспечения быстрого и релевантного поиска
+          Выберите платформу, чтобы подключить поисковый движок и настроить интеграцию под свои задачи.
         </p>
       </div>
 
-      <Tabs defaultValue="overview" className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
+        <Card className="h-fit">
+          <CardHeader>
+            <CardTitle>Разделы документации</CardTitle>
+            <CardDescription>Инструкции по интеграциям и виджетам</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {sections.map((section) => {
+              const Icon = section.icon;
+              return (
+                <Button
+                  key={section.id}
+                  variant={activeSection === section.id ? "secondary" : "ghost"}
+                  className="w-full justify-start gap-3"
+                  onClick={() => setActiveSection(section.id)}
+                >
+                  <Icon className="h-4 w-4" />
+                  <div className="flex flex-col items-start">
+                    <span className="font-semibold leading-tight">{section.title}</span>
+                    <span className="text-xs text-muted-foreground">{section.description}</span>
+                  </div>
+                </Button>
+              );
+            })}
+          </CardContent>
+        </Card>
+
+        {activeSection === "tilda" && (
+          <div className="space-y-6">
+            <div>
+              <h2 className="text-3xl font-bold mb-2 flex items-center gap-2">
+                <Globe className="h-8 w-8" />
+                API для интеграции с Тильдой
+              </h2>
+              <p className="text-lg text-muted-foreground">
+                Подключите поисковый движок к вашему сайту на Тильде для обеспечения быстрого и релевантного поиска
+              </p>
+            </div>
+
+            <Tabs defaultValue="overview" className="space-y-6">
         <TabsList className="grid w-full grid-cols-4">
           <TabsTrigger value="overview">Обзор</TabsTrigger>
           <TabsTrigger value="search">Поиск</TabsTrigger>
@@ -792,6 +842,9 @@ export default function TildaApiPage() {
           </div>
         </TabsContent>
       </Tabs>
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- переименовано меню "Сайты для краулинга" в "Проекты" и добавлены заблокированные пункты для тарифных функций
- обновлена страница документации API: новый заголовок, боковое подменю и секция Tilda с условным отображением

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d13692f3d8832697d6658b1e574e07