### PR TITLE
Добавить типы проектов и настройки векторного поиска

### DIFF
--- a/client/src/components/AddSiteForm.tsx
+++ b/client/src/components/AddSiteForm.tsx
@@ -6,9 +6,24 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Plus, X } from "lucide-react";
+import { projectTypeLabels, type ProjectType } from "@shared/schema";
+
+const PROJECT_TYPE_OPTIONS: Array<{ value: ProjectType; label: string; description: string }> = [
+  {
+    value: "search_engine",
+    label: projectTypeLabels.search_engine,
+    description: "Классический краулер сайтов с полнотекстовым поиском и настройкой ранжирования.",
+  },
+  {
+    value: "vector_search",
+    label: projectTypeLabels.vector_search,
+    description: "Проекты для семантического поиска по эмбеддингам. Настройка модели появится позже.",
+  },
+];
 
 interface SiteConfig {
   url: string;
+  projectType: ProjectType;
   crawlDepth: number;
   followExternalLinks: boolean;
   crawlFrequency: "manual" | "hourly" | "daily" | "weekly";
@@ -23,6 +38,7 @@ interface AddSiteFormProps {
 export default function AddSiteForm({ onSubmit, onCancel }: AddSiteFormProps) {
   const [config, setConfig] = useState<SiteConfig>({
     url: "",
+    projectType: "search_engine",
     crawlDepth: 3,
     followExternalLinks: false,
     crawlFrequency: "daily",
@@ -66,6 +82,28 @@ export default function AddSiteForm({ onSubmit, onCancel }: AddSiteFormProps) {
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="project-type">Тип проекта</Label>
+            <Select
+              value={config.projectType}
+              onValueChange={(value) => setConfig(prev => ({ ...prev, projectType: value as ProjectType }))}
+            >
+              <SelectTrigger id="project-type" data-testid="select-project-type">
+                <SelectValue placeholder="Выберите тип проекта" />
+              </SelectTrigger>
+              <SelectContent>
+                {PROJECT_TYPE_OPTIONS.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    <div className="flex flex-col text-left">
+                      <span className="font-medium">{option.label}</span>
+                      <span className="text-xs text-muted-foreground">{option.description}</span>
+                    </div>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
           <div>
             <Label htmlFor="url">URL сайта</Label>
             <Input

--- a/client/src/components/CrawlStatusCard.tsx
+++ b/client/src/components/CrawlStatusCard.tsx
@@ -33,6 +33,7 @@ interface CrawlStatusCardProps {
   crawlStatus: CrawlStatus;
   projectName?: string;
   projectDescription?: string | null;
+  projectTypeLabel?: string;
   href?: string;
   onStart?: (id: string) => void;
   onStop?: (id: string) => void;
@@ -106,6 +107,7 @@ export default function CrawlStatusCard({
   crawlStatus,
   projectName,
   projectDescription,
+  projectTypeLabel,
   href,
   onStart,
   onStop,
@@ -150,6 +152,11 @@ export default function CrawlStatusCard({
             <Badge variant={statusColors[crawlStatus.status]}>
               {statusLabels[crawlStatus.status]}
             </Badge>
+            {projectTypeLabel && (
+              <Badge variant="outline" className="hidden sm:inline-flex">
+                {projectTypeLabel}
+              </Badge>
+            )}
           </div>
 
           <div className="flex gap-1">
@@ -207,6 +214,12 @@ export default function CrawlStatusCard({
             )}
           </div>
         </div>
+
+        {projectTypeLabel && (
+          <div className="sm:hidden">
+            <Badge variant="outline">{projectTypeLabel}</Badge>
+          </div>
+        )}
 
         <div className="space-y-1">
           <h4 className="text-lg font-semibold leading-tight" data-testid={`text-project-${crawlStatus.id}`}>

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -3,7 +3,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import AddSiteForm, { type SiteConfig } from "@/components/AddSiteForm";
 import CrawlStatusCard, { type CrawlStatus } from "@/components/CrawlStatusCard";
-import { type Site } from "@shared/schema";
+import { projectTypeLabels, type Site } from "@shared/schema";
 
 interface Stats {
   sites: { total: number; crawling: number; completed: number; failed: number; };
@@ -333,6 +333,7 @@ export default function AdminPage() {
                   crawlStatus={mapCrawlStatus(status as Site & { pagesFound?: number; pagesIndexed?: number })}
                   projectName={getProjectName(status)}
                   projectDescription={getProjectDescription(status)}
+                  projectTypeLabel={projectTypeLabels[(status as Site).projectType] ?? projectTypeLabels.search_engine}
                   href={`/admin/sites/${status.id}`}
                   onStart={handleStartCrawl}
                   onStop={handleStopCrawl}
@@ -375,6 +376,7 @@ export default function AdminPage() {
                 crawlStatus={mapCrawlStatus(status as Site & { pagesFound?: number; pagesIndexed?: number })}
                 projectName={getProjectName(status)}
                 projectDescription={getProjectDescription(status)}
+                projectTypeLabel={projectTypeLabels[(status as Site).projectType] ?? projectTypeLabels.search_engine}
                 href={`/admin/sites/${status.id}`}
                 onStart={handleStartCrawl}
                 onStop={handleStopCrawl}
@@ -400,6 +402,7 @@ export default function AdminPage() {
                 crawlStatus={mapCrawlStatus(status as Site & { pagesFound?: number; pagesIndexed?: number })}
                 projectName={getProjectName(status)}
                 projectDescription={getProjectDescription(status)}
+                projectTypeLabel={projectTypeLabels[(status as Site).projectType] ?? projectTypeLabels.search_engine}
                 href={`/admin/sites/${status.id}`}
                 onStart={handleStartCrawl}
                 onStop={handleStopCrawl}
@@ -425,6 +428,7 @@ export default function AdminPage() {
                 crawlStatus={mapCrawlStatus(status as Site & { pagesFound?: number; pagesIndexed?: number })}
                 projectName={getProjectName(status)}
                 projectDescription={getProjectDescription(status)}
+                projectTypeLabel={projectTypeLabels[(status as Site).projectType] ?? projectTypeLabels.search_engine}
                 href={`/admin/sites/${status.id}`}
                 onStart={handleStartCrawl}
                 onStop={handleStopCrawl}

--- a/client/src/pages/SiteDetailsPage.tsx
+++ b/client/src/pages/SiteDetailsPage.tsx
@@ -12,11 +12,19 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AlertCircle, ArrowLeft, Globe, Info, Loader2 } from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
-import { defaultSearchSettings, type SearchSettings } from "@shared/schema";
+import {
+  defaultSearchSettings,
+  defaultVectorSearchSettings,
+  projectTypeLabels,
+  type ProjectType,
+  type SearchSettings,
+  type VectorSearchSettings,
+} from "@shared/schema";
 
 interface Site {
   id: string;
@@ -34,6 +42,8 @@ interface Site {
   createdAt?: string;
   updatedAt?: string;
   searchSettings?: SearchSettings;
+  projectType: ProjectType;
+  vectorSettings?: VectorSearchSettings | null;
 }
 
 interface PageSummary {
@@ -62,6 +72,9 @@ type SearchSettingPath = {
 
 const cloneSearchSettings = (settings?: SearchSettings | null): SearchSettings =>
   JSON.parse(JSON.stringify(settings ?? defaultSearchSettings)) as SearchSettings;
+
+const cloneVectorSettings = (settings?: VectorSearchSettings | null): VectorSearchSettings =>
+  JSON.parse(JSON.stringify(settings ?? defaultVectorSearchSettings)) as VectorSearchSettings;
 
 const searchSettingsSections: Array<{
   title: string;
@@ -252,6 +265,19 @@ const searchSettingsSections: Array<{
   },
 ];
 
+const PROJECT_TYPE_OPTIONS: Array<{ value: ProjectType; label: string; description: string }> = [
+  {
+    value: "search_engine",
+    label: projectTypeLabels.search_engine,
+    description: "Классический краулер с настройкой полнотекстового поиска.",
+  },
+  {
+    value: "vector_search",
+    label: projectTypeLabels.vector_search,
+    description: "Семантический поиск по эмбеддингам. Ручная настройка параметров доступна ниже.",
+  },
+];
+
 const cronPresets = [
   { label: "Каждый час", value: "0 * * * *" },
   { label: "Каждый день в 03:00", value: "0 3 * * *" },
@@ -289,6 +315,8 @@ export default function SiteDetailsPage({ siteId }: SiteDetailsPageProps) {
   const [projectName, setProjectName] = useState("");
   const [projectDescription, setProjectDescription] = useState("");
   const [projectUrl, setProjectUrl] = useState("");
+  const [projectType, setProjectType] = useState<ProjectType>("search_engine");
+  const [vectorSettingsForm, setVectorSettingsForm] = useState<VectorSearchSettings>(cloneVectorSettings());
   const [crawlMode, setCrawlMode] = useState<"manual" | "cron">("manual");
   const [cronExpression, setCronExpression] = useState("");
 
@@ -348,7 +376,13 @@ export default function SiteDetailsPage({ siteId }: SiteDetailsPageProps) {
   });
 
   const updateProjectInfoMutation = useMutation({
-    mutationFn: async (payload: { name: string; description?: string | null; url?: string | null }) => {
+    mutationFn: async (payload: {
+      name: string;
+      description?: string | null;
+      url?: string | null;
+      projectType: ProjectType;
+      vectorSettings?: VectorSearchSettings;
+    }) => {
       const response = await apiRequest("PUT", `/api/sites/${normalizedSiteId}`, payload);
       return response.json();
     },
@@ -364,6 +398,29 @@ export default function SiteDetailsPage({ siteId }: SiteDetailsPageProps) {
       toast({
         title: "Не удалось сохранить проект",
         description: "Проверьте соединение и попробуйте снова.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const updateVectorSettingsMutation = useMutation({
+    mutationFn: async (payload: VectorSearchSettings) => {
+      const response = await apiRequest("PUT", `/api/sites/${normalizedSiteId}`, {
+        vectorSettings: payload,
+      });
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["site", normalizedSiteId] });
+      toast({
+        title: "Параметры векторного поиска обновлены",
+        description: "Настройки эмбеддингов успешно сохранены.",
+      });
+    },
+    onError: () => {
+      toast({
+        title: "Не удалось сохранить векторные настройки",
+        description: "Проверьте значения и повторите попытку.",
         variant: "destructive",
       });
     },
@@ -393,16 +450,18 @@ export default function SiteDetailsPage({ siteId }: SiteDetailsPageProps) {
 
   useEffect(() => {
     setSettingsForm(cloneSearchSettings(site?.searchSettings));
-  }, [site?.searchSettings]);
+    setVectorSettingsForm(cloneVectorSettings(site?.vectorSettings));
+  }, [site?.searchSettings, site?.vectorSettings]);
 
   useEffect(() => {
     setProjectName(site?.name ?? "");
     setProjectDescription(site?.description ?? "");
     setProjectUrl(site?.url ?? "");
+    setProjectType(site?.projectType ?? "search_engine");
     const { mode, expression } = resolveFrequency(site?.crawlFrequency);
     setCrawlMode(mode);
     setCronExpression(expression);
-  }, [site?.name, site?.description, site?.url, site?.crawlFrequency]);
+  }, [site?.name, site?.description, site?.url, site?.crawlFrequency, site?.projectType]);
 
   const searchResults = searchData?.results ?? [];
   const totalResults = searchData?.total ?? 0;
@@ -457,7 +516,14 @@ export default function SiteDetailsPage({ siteId }: SiteDetailsPageProps) {
       name: trimmedName,
       description: trimmedDescription ? trimmedDescription : null,
       url: trimmedUrl ? trimmedUrl : null,
+      projectType,
+      vectorSettings: projectType === "vector_search" ? vectorSettingsForm : undefined,
     });
+  };
+
+  const handleSaveVectorSettings = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    updateVectorSettingsMutation.mutate(vectorSettingsForm);
   };
 
   const handleSaveSchedule = (event: FormEvent<HTMLFormElement>) => {
@@ -793,6 +859,27 @@ export default function SiteDetailsPage({ siteId }: SiteDetailsPageProps) {
                         data-testid="textarea-project-description-details"
                       />
                     </div>
+                    <div className="space-y-2 md:col-span-2 md:max-w-sm">
+                      <Label htmlFor="project-type">Тип проекта</Label>
+                      <Select
+                        value={projectType}
+                        onValueChange={(value) => setProjectType(value as ProjectType)}
+                      >
+                        <SelectTrigger id="project-type" data-testid="select-project-type-details">
+                          <SelectValue placeholder="Выберите тип" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {PROJECT_TYPE_OPTIONS.map(option => (
+                            <SelectItem key={option.value} value={option.value}>
+                              <div className="flex flex-col text-left">
+                                <span className="font-medium">{option.label}</span>
+                                <span className="text-xs text-muted-foreground">{option.description}</span>
+                              </div>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
                     <div className="flex justify-end gap-2 md:col-span-2">
                       <Button
                         type="submit"
@@ -805,6 +892,94 @@ export default function SiteDetailsPage({ siteId }: SiteDetailsPageProps) {
                   </form>
                 </CardContent>
               </Card>
+
+              {projectType === "vector_search" && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Настройки векторного поиска</CardTitle>
+                    <CardDescription>
+                      Укажите параметры подготовки эмбеддингов для семантического поиска по проекту.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <form className="grid gap-4 md:grid-cols-2" onSubmit={handleSaveVectorSettings}>
+                      <div className="space-y-2 md:col-span-2">
+                        <Label htmlFor="embedding-model">Модель эмбеддингов</Label>
+                        <Input
+                          id="embedding-model"
+                          value={vectorSettingsForm.embeddingModel}
+                          onChange={(event) =>
+                            setVectorSettingsForm(prev => ({
+                              ...prev,
+                              embeddingModel: event.target.value,
+                            }))
+                          }
+                          placeholder="Например, text-embedding-3-large"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="embedding-dimensions">Размерность вектора</Label>
+                        <Input
+                          id="embedding-dimensions"
+                          type="number"
+                          min={1}
+                          value={vectorSettingsForm.embeddingDimensions}
+                          onChange={(event) => {
+                            const parsed = Number(event.target.value);
+                            setVectorSettingsForm(prev => ({
+                              ...prev,
+                              embeddingDimensions: Number.isNaN(parsed)
+                                ? prev.embeddingDimensions
+                                : parsed,
+                            }));
+                          }}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="chunk-size">Размер чанка</Label>
+                        <Input
+                          id="chunk-size"
+                          type="number"
+                          min={64}
+                          value={vectorSettingsForm.chunkSize}
+                          onChange={(event) => {
+                            const parsed = Number(event.target.value);
+                            setVectorSettingsForm(prev => ({
+                              ...prev,
+                              chunkSize: Number.isNaN(parsed) ? prev.chunkSize : parsed,
+                            }));
+                          }}
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="chunk-overlap">Перекрытие чанков</Label>
+                        <Input
+                          id="chunk-overlap"
+                          type="number"
+                          min={0}
+                          value={vectorSettingsForm.chunkOverlap}
+                          onChange={(event) => {
+                            const parsed = Number(event.target.value);
+                            setVectorSettingsForm(prev => ({
+                              ...prev,
+                              chunkOverlap: Number.isNaN(parsed) ? prev.chunkOverlap : parsed,
+                            }));
+                          }}
+                        />
+                      </div>
+                      <p className="md:col-span-2 text-sm text-muted-foreground">
+                        Эти параметры используются для подготовки текстов к семантическому поиску. Настройте их под размеры
+                        документов и используемую модель.
+                      </p>
+                      <div className="flex justify-end gap-2 md:col-span-2">
+                        <Button type="submit" disabled={updateVectorSettingsMutation.isPending}>
+                          {updateVectorSettingsMutation.isPending ? "Сохранение..." : "Сохранить векторные настройки"}
+                        </Button>
+                      </div>
+                    </form>
+                  </CardContent>
+                </Card>
+              )}
 
               <Card>
                 <CardHeader>

--- a/migrations/0003_project_types.sql
+++ b/migrations/0003_project_types.sql
@@ -1,0 +1,13 @@
+DO $$
+BEGIN
+  CREATE TYPE "project_type" AS ENUM ('search_engine', 'vector_search');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE "sites" ADD COLUMN IF NOT EXISTS "project_type" "project_type" NOT NULL DEFAULT 'search_engine';
+ALTER TABLE "sites" ADD COLUMN IF NOT EXISTS "vector_settings" jsonb NOT NULL DEFAULT '{"embeddingModel":"text-embedding-3-large","embeddingDimensions":3072,"chunkSize":512,"chunkOverlap":64}'::jsonb;
+
+UPDATE "sites"
+SET "project_type" = 'search_engine'
+WHERE "project_type" IS NULL;

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -294,6 +294,20 @@
           "primaryKey": false,
           "notNull": true,
           "default": "CURRENT_TIMESTAMP"
+        },
+        "project_type": {
+          "name": "project_type",
+          "type": "project_type",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'search_engine'"
+        },
+        "vector_settings": {
+          "name": "vector_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"embeddingModel\":\"text-embedding-3-large\",\"embeddingDimensions\":3072,\"chunkSize\":512,\"chunkOverlap\":64}'::jsonb"
         }
       },
       "indexes": {},
@@ -353,7 +367,16 @@
       "isRLSEnabled": false
     }
   },
-  "enums": {},
+  "enums": {
+    "public.project_type": {
+      "name": "project_type",
+      "schema": "public",
+      "values": [
+        "search_engine",
+        "vector_search"
+      ]
+    }
+  },
   "schemas": {},
   "sequences": {},
   "roles": {},

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1758104588459,
       "tag": "0002_projects_metadata",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1758104589459,
+      "tag": "0003_project_types",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,5 @@
 import { sql, relations } from "drizzle-orm";
-import { pgTable, text, varchar, timestamp, integer, boolean, jsonb, doublePrecision, customType } from "drizzle-orm/pg-core";
+import { pgTable, text, varchar, timestamp, integer, boolean, jsonb, doublePrecision, customType, pgEnum } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -39,6 +39,30 @@ export interface SearchSettings {
   };
 }
 
+export const projectTypes = ["search_engine", "vector_search"] as const;
+export type ProjectType = (typeof projectTypes)[number];
+
+export const projectTypeEnum = pgEnum("project_type", projectTypes);
+
+export const projectTypeLabels: Record<ProjectType, string> = {
+  search_engine: "Поисковый движок",
+  vector_search: "Векторный поиск",
+};
+
+export interface VectorSearchSettings {
+  embeddingModel: string;
+  embeddingDimensions: number;
+  chunkSize: number;
+  chunkOverlap: number;
+}
+
+export const defaultVectorSearchSettings: VectorSearchSettings = {
+  embeddingModel: "text-embedding-3-large",
+  embeddingDimensions: 3072,
+  chunkSize: 512,
+  chunkOverlap: 64,
+};
+
 export const defaultSearchSettings: SearchSettings = {
   fts: {
     titleBoost: 15,
@@ -73,6 +97,13 @@ export const defaultSearchSettings: SearchSettings = {
     ilikeContentBoost: 1.5,
   },
 };
+
+export const vectorSearchSettingsSchema = z.object({
+  embeddingModel: z.string().min(1),
+  embeddingDimensions: z.number().positive(),
+  chunkSize: z.number().positive(),
+  chunkOverlap: z.number().min(0),
+});
 
 export const searchSettingsSchema = z.object({
   fts: z.object({
@@ -122,6 +153,7 @@ export const sites = pgTable("sites", {
   name: text("name").notNull().default("Новый проект"),
   description: text("description"),
   url: text("url").unique(),
+  projectType: projectTypeEnum("project_type").notNull().default("search_engine"),
   crawlDepth: integer("crawl_depth").notNull().default(3),
   followExternalLinks: boolean("follow_external_links").notNull().default(false),
   crawlFrequency: text("crawl_frequency").notNull().default("daily"), // "manual" | "hourly" | "daily" | "weekly"
@@ -131,6 +163,7 @@ export const sites = pgTable("sites", {
   nextCrawl: timestamp("next_crawl"),
   error: text("error"),
   searchSettings: jsonb("search_settings").$type<SearchSettings>().notNull().default(sql`${JSON.stringify(defaultSearchSettings)}::jsonb`),
+  vectorSettings: jsonb("vector_settings").$type<VectorSearchSettings>().notNull().default(sql`${JSON.stringify(defaultVectorSearchSettings)}::jsonb`),
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   updatedAt: timestamp("updated_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
 });
@@ -195,7 +228,9 @@ export const insertSiteSchema = createInsertSchema(sites).omit({
   nextCrawl: true,
   error: true,
 }).extend({
+  projectType: z.enum(projectTypes),
   searchSettings: searchSettingsSchema.optional(),
+  vectorSettings: vectorSearchSettingsSchema.optional(),
 });
 
 export const insertPageSchema = createInsertSchema(pages).omit({
@@ -211,6 +246,7 @@ export const insertSearchIndexSchema = createInsertSchema(searchIndex).omit({
 
 // Types
 export type Site = typeof sites.$inferSelect;
+export type VectorSearchSettingsInput = z.infer<typeof vectorSearchSettingsSchema>;
 export type InsertSite = z.infer<typeof insertSiteSchema>;
 export type Page = typeof pages.$inferSelect;
 export type InsertPage = z.infer<typeof insertPageSchema>;


### PR DESCRIPTION
## Summary
- добавить перечисление типов проектов, колонку vector_settings и миграцию для новых полей
- обновить слой хранения и схемы валидации для работы с типами проектов и настройками векторного поиска
- расширить интерфейсы админки выбором типа проекта и формой базовых настроек для векторного поиска

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d1762be26483268c9281fe3060bcf4