### PR TITLE
Добавлен просмотр содержимого коллекции Qdrant

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import AdminPage from "@/pages/AdminPage";
 import PagesPage from "@/pages/PagesPage";
 import TildaApiPage from "@/pages/TildaApiPage";
 import VectorCollectionsPage from "@/pages/VectorCollectionsPage";
+import VectorCollectionDetailPage from "@/pages/VectorCollectionDetailPage";
 import ProjectDetailPage from "@/pages/ProjectDetailPage";
 import NotFound from "@/pages/not-found";
 
@@ -22,6 +23,7 @@ function Router() {
       <Route path="/admin/sites" component={AdminPage} />
       <Route path="/admin/projects/:siteId" component={ProjectDetailPage} />
       <Route path="/admin/pages" component={PagesPage} />
+      <Route path="/admin/vector/collections/:name" component={VectorCollectionDetailPage} />
       <Route path="/admin/vector/collections" component={VectorCollectionsPage} />
       <Route path="/admin/api" component={TildaApiPage} />
       <Route path="/admin/:tab" component={AdminPage} />

--- a/client/src/pages/VectorCollectionDetailPage.tsx
+++ b/client/src/pages/VectorCollectionDetailPage.tsx
@@ -1,0 +1,338 @@
+import { useMemo } from "react";
+import { Link, useRoute } from "wouter";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
+import { ChevronLeft, RefreshCw } from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { apiRequest } from "@/lib/queryClient";
+
+interface VectorCollectionDetail {
+  name: string;
+  status: string;
+  optimizerStatus?: string | { error: string };
+  pointsCount: number;
+  vectorsCount: number | null;
+  segmentsCount: number | null;
+  vectorSize: number | null;
+  distance: string | null;
+  config?: Record<string, unknown> | null;
+}
+
+type CollectionPoint = {
+  id: string | number;
+  payload: Record<string, unknown> | null;
+  shard_key?: unknown;
+  order_value?: unknown;
+  [key: string]: unknown;
+};
+
+interface CollectionPointsResponse {
+  points: CollectionPoint[];
+  nextPageOffset: string | number | null;
+}
+
+const POINTS_PAGE_SIZE = 20;
+
+const statusLabels: Record<string, string> = {
+  green: "Готова",
+  yellow: "Оптимизируется",
+  red: "Ошибка",
+};
+
+const statusVariants: Record<string, "default" | "secondary" | "destructive"> = {
+  green: "default",
+  yellow: "secondary",
+  red: "destructive",
+};
+
+function formatNumber(value: number | null | undefined) {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+
+  return new Intl.NumberFormat("ru-RU").format(value);
+}
+
+function formatOptimizerStatus(value: VectorCollectionDetail["optimizerStatus"]) {
+  if (!value) {
+    return "—";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (value.error) {
+    return `Ошибка: ${value.error}`;
+  }
+
+  return "—";
+}
+
+function formatValue(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+
+  if (value === undefined) {
+    return "—";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (error) {
+    console.error("Не удалось преобразовать значение в строку", error);
+    return String(value);
+  }
+}
+
+export default function VectorCollectionDetailPage() {
+  const [match, params] = useRoute("/admin/vector/collections/:name");
+  const encodedName = params?.name ?? "";
+  const collectionName = encodedName ? decodeURIComponent(encodedName) : null;
+
+  const {
+    data: collection,
+    isLoading: collectionLoading,
+    isFetching: collectionFetching,
+    error: collectionError,
+    refetch: refetchCollection,
+  } = useQuery<VectorCollectionDetail>({
+    queryKey: ["/api/vector/collections", collectionName ?? ""],
+    enabled: Boolean(collectionName),
+  });
+
+  const {
+    data: pointsData,
+    isLoading: pointsLoading,
+    isFetching: pointsFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    error: pointsError,
+    refetch: refetchPoints,
+  } = useInfiniteQuery<CollectionPointsResponse, Error>({
+    queryKey: ["/api/vector/collections", collectionName ?? "", "points"],
+    initialPageParam: undefined as string | number | undefined,
+    enabled: Boolean(collectionName),
+    queryFn: async ({ pageParam }) => {
+      if (!collectionName) {
+        return { points: [], nextPageOffset: null };
+      }
+
+      const params = new URLSearchParams();
+      params.set("limit", String(POINTS_PAGE_SIZE));
+      if (pageParam !== undefined && pageParam !== null) {
+        params.set("offset", String(pageParam));
+      }
+
+      const response = await apiRequest(
+        "GET",
+        `/api/vector/collections/${encodeURIComponent(collectionName)}/points?${params.toString()}`,
+      );
+      return (await response.json()) as CollectionPointsResponse;
+    },
+    getNextPageParam: (lastPage) => lastPage.nextPageOffset ?? undefined,
+  });
+
+  const isRefreshing = collectionFetching || pointsFetching;
+
+  const points = useMemo(() => {
+    return pointsData?.pages.flatMap((page) => page.points) ?? [];
+  }, [pointsData]);
+
+  if (!match) {
+    return null;
+  }
+
+  if (!collectionName) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertTitle>Коллекция не найдена</AlertTitle>
+          <AlertDescription>Не удалось определить имя коллекции.</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  const handleRefresh = () => {
+    void refetchCollection();
+    void refetchPoints();
+  };
+
+  const infoRows: Array<{ label: string; value: string }> = [
+    { label: "Статус", value: statusLabels[collection?.status ?? ""] ?? collection?.status ?? "—" },
+    { label: "Оптимизатор", value: formatOptimizerStatus(collection?.optimizerStatus) },
+    { label: "Записей", value: formatNumber(collection?.pointsCount) },
+    { label: "Векторов", value: formatNumber(collection?.vectorsCount) },
+    { label: "Размер вектора", value: formatNumber(collection?.vectorSize) },
+    { label: "Метрика", value: collection?.distance ?? "—" },
+    { label: "Сегментов", value: formatNumber(collection?.segmentsCount) },
+  ];
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Button asChild variant="ghost" size="sm" className="gap-2 px-2">
+            <Link href="/admin/vector/collections">
+              <ChevronLeft className="h-4 w-4" />
+              Назад к коллекциям
+            </Link>
+          </Button>
+          {collection?.status && (
+            <Badge variant={statusVariants[collection.status] ?? "secondary"}>
+              {statusLabels[collection.status] ?? collection.status}
+            </Badge>
+          )}
+        </div>
+        <Button variant="outline" onClick={handleRefresh} disabled={isRefreshing}>
+          <RefreshCw className="mr-2 h-4 w-4" />
+          Обновить
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold">
+          {collectionLoading ? <Skeleton className="h-7 w-56" /> : collection?.name ?? collectionName}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Просмотр содержимого и параметров коллекции Qdrant
+        </p>
+      </div>
+
+      {collectionError && (
+        <Alert variant="destructive">
+          <AlertTitle>Не удалось загрузить информацию</AlertTitle>
+          <AlertDescription>{(collectionError as Error).message}</AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Информация о коллекции</CardTitle>
+          <CardDescription>
+            Подробные сведения о конфигурации и состоянии коллекции
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableBody>
+                {infoRows.map((row) => (
+                  <TableRow key={row.label}>
+                    <TableCell className="w-48 font-medium">{row.label}</TableCell>
+                    <TableCell>{row.value}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Записи коллекции</CardTitle>
+          <CardDescription>
+            Отображаются все поля записей, кроме векторов
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {pointsError && (
+            <Alert variant="destructive">
+              <AlertTitle>Не удалось загрузить записи</AlertTitle>
+              <AlertDescription>{pointsError.message}</AlertDescription>
+            </Alert>
+          )}
+
+          {pointsLoading && !points.length ? (
+            <p className="text-muted-foreground">Загрузка записей...</p>
+          ) : points.length === 0 ? (
+            <p className="text-muted-foreground">В коллекции пока нет записей.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-40">ID</TableHead>
+                    <TableHead>Данные</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {points.map((point) => {
+                    const { payload, ...rest } = point;
+                    const extraFields = Object.entries(rest).filter(([key, value]) => key !== "id" && value !== undefined);
+
+                    return (
+                      <TableRow key={String(point.id)}>
+                        <TableCell>
+                          <span className="font-mono text-sm">{point.id}</span>
+                        </TableCell>
+                        <TableCell>
+                          <div className="space-y-4">
+                            <div>
+                              <p className="text-xs font-medium uppercase text-muted-foreground">Payload</p>
+                              {payload && Object.keys(payload).length > 0 ? (
+                                <div className="mt-2 space-y-3">
+                                  {Object.entries(payload).map(([key, value]) => (
+                                    <div key={key}>
+                                      <p className="text-xs font-medium text-muted-foreground">{key}</p>
+                                      <pre className="mt-1 whitespace-pre-wrap break-words rounded-md bg-muted/50 p-2 text-xs">
+                                        {formatValue(value)}
+                                      </pre>
+                                    </div>
+                                  ))}
+                                </div>
+                              ) : (
+                                <p className="text-sm text-muted-foreground">Пустой payload</p>
+                              )}
+                            </div>
+
+                            {extraFields.length > 0 && (
+                              <div className="space-y-3">
+                                {extraFields.map(([key, value]) => (
+                                  <div key={key}>
+                                    <p className="text-xs font-medium uppercase text-muted-foreground">{key}</p>
+                                    <pre className="mt-1 whitespace-pre-wrap break-words rounded-md bg-muted/50 p-2 text-xs">
+                                      {formatValue(value)}
+                                    </pre>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+
+          {hasNextPage && (
+            <div className="flex justify-center">
+              <Button onClick={() => fetchNextPage()} disabled={isFetchingNextPage} variant="outline">
+                {isFetchingNextPage ? "Загрузка..." : "Загрузить ещё"}
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/pages/VectorCollectionsPage.tsx
+++ b/client/src/pages/VectorCollectionsPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link, useLocation } from "wouter";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -86,6 +87,7 @@ export default function VectorCollectionsPage() {
   });
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [collectionToDelete, setCollectionToDelete] = useState<string | null>(null);
+  const [, setLocation] = useLocation();
 
   const { data, isLoading, isFetching, error } = useQuery<CollectionsResponse>({
     queryKey: ["/api/vector/collections"],
@@ -276,7 +278,12 @@ export default function VectorCollectionsPage() {
                     <TableRow key={collection.name}>
                       <TableCell className="font-medium">
                         <div className="flex flex-col">
-                          <span>{collection.name}</span>
+                          <Link
+                            href={`/admin/vector/collections/${encodeURIComponent(collection.name)}`}
+                            className="text-primary hover:underline"
+                          >
+                            {collection.name}
+                          </Link>
                           {collection.error && (
                             <span className="text-xs text-destructive">{collection.error}</span>
                           )}
@@ -294,6 +301,14 @@ export default function VectorCollectionsPage() {
                             </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onSelect={(event) => {
+                                event.preventDefault();
+                                setLocation(`/admin/vector/collections/${encodeURIComponent(collection.name)}`);
+                              }}
+                            >
+                              Открыть коллекцию
+                            </DropdownMenuItem>
                             <DropdownMenuItem
                               onSelect={(event) => {
                                 event.preventDefault();


### PR DESCRIPTION
## Summary
- добавлена страница с подробной информацией о коллекции и списком записей
- реализован API-эндпоинт для постраничного просмотра записей коллекции без векторов
- добавлены переходы из списка коллекций на страницу деталей

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d39b19815483268a1c559ee0f599cf