### PR TITLE
Ensure pages schema columns exist on startup

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,7 @@ import express, { type Request, Response, NextFunction } from "express";
 import cors from "cors";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
-import { storage } from "./storage";
+import { storage, ensureDatabaseSchema } from "./storage";
 import { getAllowedHostnames } from "./cors-cache";
 import fs from "fs";
 import path from "path";
@@ -106,6 +106,13 @@ app.use((req, res, next) => {
 });
 
 (async () => {
+  try {
+    await ensureDatabaseSchema();
+    log("Проверка схемы базы данных выполнена");
+  } catch (error) {
+    log(`Не удалось подготовить схему базы данных: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
   // Reset any stuck crawling sites on server startup
   try {
     const sites = await storage.getAllSites();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -325,3 +325,20 @@ export class DatabaseStorage implements IStorage {
 }
 
 export const storage = new DatabaseStorage();
+
+export async function ensureDatabaseSchema(): Promise<void> {
+  try {
+    await db.execute(sql`
+      ALTER TABLE "pages"
+      ADD COLUMN IF NOT EXISTS "metadata" jsonb DEFAULT '{}'::jsonb NOT NULL
+    `);
+
+    await db.execute(sql`
+      ALTER TABLE "pages"
+      ADD COLUMN IF NOT EXISTS "chunks" jsonb DEFAULT '[]'::jsonb NOT NULL
+    `);
+  } catch (error) {
+    console.error("[storage] Не удалось обновить схему базы данных", error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- добавил проверку и автоматическое создание колонок metadata и chunks в таблице страниц при запуске сервера
- подключил эту проверку при старте приложения, чтобы избежать падений запросов из-за отсутствия колонок

## Testing
- npm run check *(fails: cheerio type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c0619ff08326a77d4ce7651bcd71