### PR TITLE
Поддержка проектов с несколькими стартовыми URL

### DIFF
--- a/migrations/0004_projects_multi_url_and_chunks.sql
+++ b/migrations/0004_projects_multi_url_and_chunks.sql
@@ -1,0 +1,21 @@
+ALTER TABLE "sites" ADD COLUMN IF NOT EXISTS "name" text DEFAULT 'Новый проект';
+ALTER TABLE "sites" ADD COLUMN IF NOT EXISTS "start_urls" jsonb NOT NULL DEFAULT '[]'::jsonb;
+ALTER TABLE "sites" ADD COLUMN IF NOT EXISTS "max_chunk_size" integer NOT NULL DEFAULT 1200;
+
+UPDATE "sites"
+SET "name" = COALESCE(NULLIF("name", ''), CASE
+  WHEN "url" IS NOT NULL AND "url" <> '' THEN 'Проект ' || split_part("url", '://', 2)
+  ELSE 'Новый проект'
+END);
+
+UPDATE "sites"
+SET "start_urls" = CASE
+  WHEN jsonb_typeof("start_urls") = 'array' AND jsonb_array_length("start_urls") > 0 THEN "start_urls"
+  WHEN "url" IS NOT NULL AND "url" <> '' THEN jsonb_build_array("url")
+  ELSE '[]'::jsonb
+END;
+
+ALTER TABLE "sites" ALTER COLUMN "name" SET NOT NULL;
+ALTER TABLE "sites" ALTER COLUMN "name" SET DEFAULT 'Новый проект';
+ALTER TABLE "sites" ALTER COLUMN "crawl_frequency" SET DEFAULT 'manual';
+UPDATE "sites" SET "crawl_frequency" = 'manual';

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -209,11 +209,25 @@
           "notNull": true,
           "default": "gen_random_uuid()"
         },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Новый проект'"
+        },
         "url": {
           "name": "url",
           "type": "text",
           "primaryKey": false,
           "notNull": true
+        },
+        "start_urls": {
+          "name": "start_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
         },
         "crawl_depth": {
           "name": "crawl_depth",
@@ -221,6 +235,13 @@
           "primaryKey": false,
           "notNull": true,
           "default": 3
+        },
+        "max_chunk_size": {
+          "name": "max_chunk_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1200
         },
         "follow_external_links": {
           "name": "follow_external_links",
@@ -234,7 +255,7 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
-          "default": "'daily'"
+          "default": "'manual'"
         },
         "exclude_patterns": {
           "name": "exclude_patterns",

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1758104589459,
       "tag": "0003_remove_project_metadata",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1758104590459,
+      "tag": "0004_projects_multi_url_and_chunks",
+      "breakpoints": true
     }
   ]
 }

--- a/server/cors-cache.ts
+++ b/server/cors-cache.ts
@@ -21,15 +21,18 @@ export async function refreshCorsCache(): Promise<Set<string>> {
     
     // Process database sites and extract hostnames
     for (const site of sites) {
-      if (!site.url) {
-        continue;
-      }
-      try {
-        const url = new URL(site.url);
-        hostnames.add(url.hostname);
-      } catch (urlError) {
-        log(`CORS cache: Invalid URL in database: ${site.url} - ${urlError}`);
-        // Skip invalid URLs instead of breaking the entire cache
+      const urlsToProcess = site.startUrls?.length ? site.startUrls : site.url ? [site.url] : [];
+
+      for (const rawUrl of urlsToProcess) {
+        if (!rawUrl) {
+          continue;
+        }
+        try {
+          const url = new URL(rawUrl);
+          hostnames.add(url.hostname);
+        } catch (urlError) {
+          log(`CORS cache: Invalid URL in database: ${rawUrl} - ${urlError}`);
+        }
       }
     }
     


### PR DESCRIPTION
## Summary
- добавить миграцию и обновить схему проекта для хранения названия, массива стартовых URL и размера чанка
- переработать админский интерфейс: модальное окно добавления проекта, новая форма с несколькими URL и фильтрацией по названию
- обновить карточку статуса краулинга для отображения параметров проекта и списка точек входа; адаптировать серверные маршруты и краулер к новым полям

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d3c6dae4ec8326b00c6ccd376beaad