### PR TITLE
Add backend webhook forwarder for JSON sending

### DIFF
--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -362,20 +362,26 @@ export default function ProjectDetailPage() {
     setIsSendingJson(true);
 
     try {
-      const response = await fetch(webhookUrl, {
+      const response = await fetch("/api/webhook/send-json", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: jsonDialogState.jsonText,
+        body: JSON.stringify({ webhookUrl, payload: jsonDialogState.jsonText }),
       });
 
+      const result = await response.json().catch(() => null);
+
       if (!response.ok) {
-        const details = await response.text();
-        throw new Error(details || "Сервер вернул ошибку");
+        const errorMessage =
+          (result && (result.error ?? result.details)) ||
+          "Сервер вернул ошибку";
+        throw new Error(errorMessage);
       }
 
       toast({
         title: "JSON отправлен",
-        description: "Данные успешно переданы на указанный вебхук.",
+        description:
+          (result && (result.message || result.details)) ||
+          "Данные успешно переданы на указанный вебхук.",
       });
 
       resetJsonDialogState();

--- a/types/jspdf.d.ts
+++ b/types/jspdf.d.ts
@@ -1,0 +1,1 @@
+declare module "jspdf";


### PR DESCRIPTION
## Summary
- add a backend webhook JSON forwarding endpoint that validates payloads and proxies POST requests
- update the project detail page to send JSON through the server and surface webhook responses
- declare the jspdf module locally so TypeScript checks continue to pass

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d40a5a85dc832687ed7e403caf3e85