### PR TITLE
Добавлены роли пользователей и админ-панель

### DIFF
--- a/client/src/components/AdminSidebar.tsx
+++ b/client/src/components/AdminSidebar.tsx
@@ -28,6 +28,7 @@ import {
   Brain,
   ChevronLeft,
   ChevronRight,
+  Users,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -119,6 +120,16 @@ export default function AdminSidebar() {
   };
 
   const sections: Array<{ label: string; items: SidebarItem[] }> = [
+    {
+      label: "Администрирование",
+      items: [
+        {
+          title: "Пользователи",
+          url: "/admin/users",
+          icon: Users,
+        },
+      ],
+    },
     {
       label: "Основное",
       items: [

--- a/client/src/pages/AdminUsersPage.tsx
+++ b/client/src/pages/AdminUsersPage.tsx
@@ -1,0 +1,170 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, ShieldCheck, ShieldOff } from "lucide-react";
+import type { PublicUser } from "@shared/schema";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface UsersResponse {
+  users: PublicUser[];
+}
+
+interface UpdateRolePayload {
+  userId: string;
+  role: PublicUser["role"];
+}
+
+function formatLastActivity(value: string | Date | null | undefined): string {
+  if (!value) {
+    return "Нет данных";
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Нет данных";
+  }
+
+  return new Intl.DateTimeFormat("ru-RU", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export default function AdminUsersPage() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const { data, isLoading, error } = useQuery<UsersResponse>({
+    queryKey: ["/api/admin/users"],
+  });
+
+  const updateRoleMutation = useMutation({
+    mutationFn: async ({ userId, role }: UpdateRolePayload) => {
+      const response = await apiRequest("PATCH", `/api/admin/users/${userId}/role`, { role });
+      return (await response.json()) as { user: PublicUser };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/admin/users"] });
+      toast({
+        title: "Роль обновлена",
+        description: "Права пользователя успешно изменены",
+      });
+    },
+    onError: (mutationError: unknown) => {
+      const message = mutationError instanceof Error ? mutationError.message : "Неизвестная ошибка";
+      toast({
+        title: "Не удалось обновить роль",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const users = data?.users ?? [];
+
+  const sortedUsers = useMemo(() => {
+    return [...users].sort((a, b) => a.fullName.localeCompare(b.fullName));
+  }, [users]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center p-10 text-muted-foreground">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+        Загрузка списка пользователей...
+      </div>
+    );
+  }
+
+  if (error) {
+    const message = error instanceof Error ? error.message : "Не удалось загрузить пользователей";
+    return (
+      <div className="p-6">
+        <h1 className="text-2xl font-semibold mb-2">Пользователи</h1>
+        <p className="text-destructive">{message}</p>
+      </div>
+    );
+  }
+
+  const pendingUserId = updateRoleMutation.variables?.userId;
+
+  const handleToggleRole = (user: PublicUser) => {
+    const nextRole = user.role === "admin" ? "user" : "admin";
+    updateRoleMutation.mutate({ userId: user.id, role: nextRole });
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-semibold">Пользователи</h1>
+        <p className="text-muted-foreground">
+          Управляйте доступом к платформе и просматривайте активность всех зарегистрированных пользователей.
+        </p>
+      </div>
+
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[280px]">Имя</TableHead>
+              <TableHead>Email</TableHead>
+              <TableHead>Роль</TableHead>
+              <TableHead>Последняя активность</TableHead>
+              <TableHead className="text-right">Действия</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sortedUsers.map((user) => {
+              const isPending = updateRoleMutation.isPending && pendingUserId === user.id;
+              const isAdmin = user.role === "admin";
+
+              return (
+                <TableRow key={user.id}>
+                  <TableCell className="font-medium">{user.fullName}</TableCell>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell>
+                    <Badge variant={isAdmin ? "destructive" : "secondary"} className="capitalize">
+                      {isAdmin ? "Админ" : "Пользователь"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>{formatLastActivity(user.lastActiveAt)}</TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant={isAdmin ? "outline" : "default"}
+                      size="sm"
+                      onClick={() => handleToggleRole(user)}
+                      disabled={isPending}
+                    >
+                      {isPending ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Обновляем...
+                        </>
+                      ) : isAdmin ? (
+                        <>
+                          <ShieldOff className="mr-2 h-4 w-4" /> Снять роль
+                        </>
+                      ) : (
+                        <>
+                          <ShieldCheck className="mr-2 h-4 w-4" /> Назначить админом
+                        </>
+                      )}
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+            {sortedUsers.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} className="py-10 text-center text-muted-foreground">
+                  Пока нет зарегистрированных пользователей
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/migrations/0006_user_roles.sql
+++ b/migrations/0006_user_roles.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "role" text DEFAULT 'user';
+UPDATE "users" SET "role" = COALESCE("role", 'user');
+ALTER TABLE "users" ALTER COLUMN "role" SET NOT NULL;
+
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "last_active_at" timestamp DEFAULT CURRENT_TIMESTAMP;
+UPDATE "users" SET "last_active_at" = COALESCE("last_active_at", "updated_at", CURRENT_TIMESTAMP);
+ALTER TABLE "users" ALTER COLUMN "last_active_at" SET NOT NULL;
+
+UPDATE "users" SET "role" = 'admin' WHERE "email" = 'forlandeivan@gmail.com';

--- a/migrations/meta/0000_snapshot.json
+++ b/migrations/meta/0000_snapshot.json
@@ -369,6 +369,20 @@
           "primaryKey": false,
           "notNull": true
         },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'::text"
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
         "created_at": {
           "name": "created_at",
           "type": "timestamp",

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1758104591459,
       "tag": "0005_platform_users",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1758104592459,
+      "tag": "0006_user_roles",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -57,19 +57,26 @@ export interface PageMetadata {
 }
 
 // Users table for platform authentication
+export const userRoles = ["admin", "user"] as const;
+export type UserRole = (typeof userRoles)[number];
+
 export const users = pgTable("users", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   email: text("email").notNull().unique(),
   fullName: text("full_name").notNull(),
   passwordHash: text("password_hash").notNull(),
+  role: text("role").$type<UserRole>().notNull().default("user"),
+  lastActiveAt: timestamp("last_active_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   updatedAt: timestamp("updated_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
 });
 
 export const insertUserSchema = createInsertSchema(users).omit({
   id: true,
+  role: true,
   createdAt: true,
   updatedAt: true,
+  lastActiveAt: true,
 });
 
 export const registerUserSchema = z


### PR DESCRIPTION
## Summary
- добавлена система ролей пользователей с хранением роли и времени последней активности, а также защита маршрутов на сервере
- реализованы API администратора для просмотра и изменения ролей, обновлен клиент с разграничением интерфейсов и новой страницей "Пользователи"
- создана миграция для добавления полей и назначения роли admin нужному пользователю, обновлено боковое меню админ-панели

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4ed123a3c8326935c44c9a62e67d5