### PR TITLE
Перераспределение пользовательских разделов между меню

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,14 +28,6 @@ function AdminRouter() {
   return (
     <Switch>
       <Route path="/admin/users" component={AdminUsersPage} />
-      <Route path="/admin/sites" component={AdminPage} />
-      <Route path="/admin/projects/:siteId" component={ProjectDetailPage} />
-      <Route path="/admin/pages" component={PagesPage} />
-      <Route path="/admin/knowledge" component={KnowledgeBasePage} />
-      <Route path="/admin/vector/collections/:name" component={VectorCollectionDetailPage} />
-      <Route path="/admin/vector/collections" component={VectorCollectionsPage} />
-      <Route path="/admin/api" component={TildaApiPage} />
-      <Route path="/admin/:tab" component={AdminPage} />
       <Route path="/admin" component={AdminUsersPage} />
       <Route component={NotFound} />
     </Switch>
@@ -45,6 +37,13 @@ function AdminRouter() {
 function MainRouter() {
   return (
     <Switch>
+      <Route path="/projects/:siteId" component={ProjectDetailPage} />
+      <Route path="/projects" component={AdminPage} />
+      <Route path="/knowledge" component={KnowledgeBasePage} />
+      <Route path="/pages" component={PagesPage} />
+      <Route path="/vector/collections/:name" component={VectorCollectionDetailPage} />
+      <Route path="/vector/collections" component={VectorCollectionsPage} />
+      <Route path="/integrations/api" component={TildaApiPage} />
       <Route path="/" component={SearchPage} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/components/AdminSidebar.tsx
+++ b/client/src/components/AdminSidebar.tsx
@@ -18,12 +18,6 @@ import {
   Users,
   Settings,
   CreditCard,
-  BookOpen,
-  Webhook,
-  Boxes,
-  Brain,
-  Globe,
-  Database,
   ChevronLeft,
   ChevronRight,
   ShieldCheck,
@@ -94,55 +88,13 @@ export default function AdminSidebar() {
     );
   };
 
-  const sections: Array<{ label: string; items: SidebarItem[] }> = [
+  const sections: Array<{ label?: string; items: SidebarItem[] }> = [
     {
-      label: "Команда",
       items: [
         {
           title: "Пользователи",
           url: "/admin/users",
           icon: Users,
-        },
-      ],
-    },
-    {
-      label: "Поисковая платформа",
-      items: [
-        {
-          title: "Проекты",
-          url: "/admin/sites",
-          icon: Globe,
-        },
-        {
-          title: "Загрузка знаний",
-          url: "/admin/knowledge",
-          icon: Brain,
-        },
-        {
-          title: "Индексированные страницы",
-          url: "/admin/pages",
-          icon: Database,
-        },
-        {
-          title: "Векторные коллекции",
-          url: "/admin/vector/collections",
-          icon: Boxes,
-        },
-      ],
-    },
-    {
-      label: "Интеграции",
-      items: [
-        {
-          title: "Документация API",
-          url: "/admin/api",
-          icon: BookOpen,
-        },
-        {
-          title: "Вебхуки",
-          url: "/admin/webhooks",
-          icon: Webhook,
-          locked: true,
         },
       ],
     },
@@ -197,9 +149,9 @@ export default function AdminSidebar() {
       </SidebarHeader>
 
       <SidebarContent>
-        {sections.map((section) => (
-          <SidebarGroup key={section.label}>
-            <SidebarGroupLabel>{section.label}</SidebarGroupLabel>
+        {sections.map((section, index) => (
+          <SidebarGroup key={section.label ?? index}>
+            {section.label ? <SidebarGroupLabel>{section.label}</SidebarGroupLabel> : null}
             <SidebarGroupContent>
               <SidebarMenu>
                 {section.items.map((item) => (

--- a/client/src/components/MainSidebar.tsx
+++ b/client/src/components/MainSidebar.tsx
@@ -133,14 +133,14 @@ export default function MainSidebar({ showAdminLink = false }: MainSidebarProps)
         },
         {
           title: "Проекты",
-          url: "/admin/sites",
+          url: "/projects",
           icon: Globe,
           badge: sites ? sites.length.toString() : "0",
           badgeVariant: "secondary",
         },
         {
           title: "Загрузка знаний",
-          url: "/admin/knowledge",
+          url: "/knowledge",
           icon: Brain,
         },
       ],
@@ -150,26 +150,26 @@ export default function MainSidebar({ showAdminLink = false }: MainSidebarProps)
       items: [
         {
           title: "Индексированные страницы",
-          url: "/admin/pages",
+          url: "/pages",
           icon: Database,
           badge: stats?.pages ? stats.pages.total.toString() : "0",
           badgeVariant: "default",
         },
         {
           title: "Статистика каулинга",
-          url: "/admin/stats",
+          url: "/stats",
           icon: Activity,
           locked: true,
         },
         {
           title: "Расписание",
-          url: "/admin/schedule",
+          url: "/schedule",
           icon: Calendar,
           locked: true,
         },
         {
           title: "Вебхуки",
-          url: "/admin/webhooks",
+          url: "/integrations/webhooks",
           icon: Webhook,
           locked: true,
         },
@@ -180,7 +180,7 @@ export default function MainSidebar({ showAdminLink = false }: MainSidebarProps)
       items: [
         {
           title: "Коллекции",
-          url: "/admin/vector/collections",
+          url: "/vector/collections",
           icon: Boxes,
         },
       ],
@@ -190,12 +190,12 @@ export default function MainSidebar({ showAdminLink = false }: MainSidebarProps)
       items: [
         {
           title: "Документация API",
-          url: "/admin/api",
+          url: "/integrations/api",
           icon: BookOpen,
         },
         {
           title: "Настройки",
-          url: "/admin/settings",
+          url: "/settings",
           icon: Settings,
           locked: true,
         },

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -357,7 +357,7 @@ export default function AdminPage() {
                   maxChunkSize={status.maxChunkSize}
                   chunkOverlap={status.chunkOverlap}
                   chunkOverlapSize={status.chunkOverlapSize}
-                  href={`/admin/projects/${status.id}`}
+                  href={`/projects/${status.id}`}
                   onStart={handleStartCrawl}
                   onStop={handleStopCrawl}
                   onRetry={handleRetryCrawl}
@@ -404,7 +404,7 @@ export default function AdminPage() {
                   maxChunkSize={status.maxChunkSize}
                   chunkOverlap={status.chunkOverlap}
                   chunkOverlapSize={status.chunkOverlapSize}
-                  href={`/admin/projects/${status.id}`}
+                  href={`/projects/${status.id}`}
                 onStart={handleStartCrawl}
                 onStop={handleStopCrawl}
                 onRetry={handleRetryCrawl}
@@ -434,7 +434,7 @@ export default function AdminPage() {
                   maxChunkSize={status.maxChunkSize}
                   chunkOverlap={status.chunkOverlap}
                   chunkOverlapSize={status.chunkOverlapSize}
-                  href={`/admin/projects/${status.id}`}
+                  href={`/projects/${status.id}`}
                 onStart={handleStartCrawl}
                 onStop={handleStopCrawl}
                 onRetry={handleRetryCrawl}
@@ -464,7 +464,7 @@ export default function AdminPage() {
                   maxChunkSize={status.maxChunkSize}
                   chunkOverlap={status.chunkOverlap}
                   chunkOverlapSize={status.chunkOverlapSize}
-                  href={`/admin/projects/${status.id}`}
+                  href={`/projects/${status.id}`}
                 onStart={handleStartCrawl}
                 onStop={handleStopCrawl}
                 onRetry={handleRetryCrawl}

--- a/client/src/pages/ProjectDetailPage.tsx
+++ b/client/src/pages/ProjectDetailPage.tsx
@@ -117,7 +117,7 @@ function calculateWordCount(text?: string | null): number {
 }
 
 export default function ProjectDetailPage() {
-  const [match, params] = useRoute("/admin/projects/:siteId");
+  const [match, params] = useRoute("/projects/:siteId");
   const siteId = params?.siteId ?? null;
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -443,7 +443,7 @@ export default function ProjectDetailPage() {
     <div className="flex flex-col gap-6 p-6">
       <div className="flex items-center gap-3">
         <Button asChild variant="ghost" size="sm" className="gap-2 px-2">
-          <Link href="/admin">
+          <Link href="/projects">
             <ChevronLeft className="h-4 w-4" />
             Назад к проектам
           </Link>

--- a/client/src/pages/VectorCollectionDetailPage.tsx
+++ b/client/src/pages/VectorCollectionDetailPage.tsx
@@ -100,7 +100,7 @@ function formatValue(value: unknown): string {
 }
 
 export default function VectorCollectionDetailPage() {
-  const [match, params] = useRoute("/admin/vector/collections/:name");
+  const [match, params] = useRoute("/vector/collections/:name");
   const encodedName = params?.name ?? "";
   const collectionName = encodedName ? decodeURIComponent(encodedName) : null;
 
@@ -202,27 +202,27 @@ export default function VectorCollectionDetailPage() {
     },
   ];
 
-  return (
-    <div className="flex flex-col gap-6 p-6">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <Button asChild variant="ghost" size="sm" className="gap-2 px-2">
-            <Link href="/admin/vector/collections">
-              <ChevronLeft className="h-4 w-4" />
-              Назад к коллекциям
-            </Link>
+    return (
+      <div className="flex flex-col gap-6 p-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Button asChild variant="ghost" size="sm" className="gap-2 px-2">
+              <Link href="/vector/collections">
+                <ChevronLeft className="h-4 w-4" />
+                Назад к коллекциям
+              </Link>
+            </Button>
+            {collection?.status && (
+              <Badge variant={statusVariants[collection.status] ?? "secondary"}>
+                {statusLabels[collection.status] ?? collection.status}
+              </Badge>
+            )}
+          </div>
+          <Button variant="outline" onClick={handleRefresh} disabled={isRefreshing}>
+            <RefreshCw className="mr-2 h-4 w-4" />
+            Обновить
           </Button>
-          {collection?.status && (
-            <Badge variant={statusVariants[collection.status] ?? "secondary"}>
-              {statusLabels[collection.status] ?? collection.status}
-            </Badge>
-          )}
         </div>
-        <Button variant="outline" onClick={handleRefresh} disabled={isRefreshing}>
-          <RefreshCw className="mr-2 h-4 w-4" />
-          Обновить
-        </Button>
-      </div>
 
       <div className="space-y-2">
         <h1 className="text-2xl font-bold">

--- a/client/src/pages/VectorCollectionsPage.tsx
+++ b/client/src/pages/VectorCollectionsPage.tsx
@@ -279,7 +279,7 @@ export default function VectorCollectionsPage() {
                       <TableCell className="font-medium">
                         <div className="flex flex-col">
                           <Link
-                            href={`/admin/vector/collections/${encodeURIComponent(collection.name)}`}
+                            href={`/vector/collections/${encodeURIComponent(collection.name)}`}
                             className="text-primary hover:underline"
                           >
                             {collection.name}
@@ -304,7 +304,7 @@ export default function VectorCollectionsPage() {
                             <DropdownMenuItem
                               onSelect={(event) => {
                                 event.preventDefault();
-                                setLocation(`/admin/vector/collections/${encodeURIComponent(collection.name)}`);
+                                setLocation(`/vector/collections/${encodeURIComponent(collection.name)}`);
                               }}
                             >
                               Открыть коллекцию


### PR DESCRIPTION
## Summary
- вынес рабочие разделы поисковой платформы из административного меню и оставил там только управление пользователями и заглушки настроек
- обновил основное меню и маршруты приложения, чтобы проекты, загрузка знаний, индексированные страницы и векторные коллекции открывались из пользовательской области
- скорректировал страницы проектов и векторных коллекций под новые пути и ссылки

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d504f99e408326b05a91061ef7e5e4