### PR TITLE
feat: support templated Qdrant config and credential testing

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -107,6 +107,13 @@ const createVectorCollectionSchema = z.object({
   onDiskPayload: z.boolean().optional(),
 });
 
+const testEmbeddingCredentialsSchema = z.object({
+  tokenUrl: z.string().trim().url("Некорректный URL для получения токена"),
+  authorizationKey: z.string().trim().min(1, "Укажите Authorization key"),
+  scope: z.string().trim().min(1, "Укажите OAuth scope"),
+  requestHeaders: z.record(z.string()).default({}),
+});
+
 const upsertPointsSchema = z.object({
   wait: z.boolean().optional(),
   ordering: z.enum(["weak", "medium", "strong"]).optional(),
@@ -313,6 +320,86 @@ export async function registerRoutes(app: Express): Promise<Server> {
       });
 
       res.status(201).json({ provider: toPublicEmbeddingProvider(provider) });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ message: "Некорректные данные", details: error.issues });
+      }
+
+      next(error);
+    }
+  });
+
+  app.post("/api/embedding/services/test-credentials", requireAdmin, async (req, res, next) => {
+    try {
+      const payload = testEmbeddingCredentialsSchema.parse(req.body);
+
+      const headers = new Headers();
+      headers.set("Authorization", payload.authorizationKey);
+      headers.set("Content-Type", "application/x-www-form-urlencoded");
+      headers.set("Accept", "application/json");
+
+      for (const [key, value] of Object.entries(payload.requestHeaders)) {
+        headers.set(key, value);
+      }
+
+      let tokenResponse: globalThis.Response;
+      try {
+        tokenResponse = await fetch(payload.tokenUrl, {
+          method: "POST",
+          headers,
+          body: new URLSearchParams({ scope: payload.scope }).toString(),
+        });
+      } catch (_error) {
+        return res.status(502).send("Не удалось подключиться к сервису эмбеддингов");
+      }
+
+      const rawBody = await tokenResponse.text();
+      let parsedBody: unknown = null;
+
+      if (rawBody) {
+        try {
+          parsedBody = JSON.parse(rawBody);
+        } catch {
+          parsedBody = rawBody;
+        }
+      }
+
+      if (!tokenResponse.ok) {
+        let message = `Сервис вернул статус ${tokenResponse.status}`;
+
+        if (parsedBody && typeof parsedBody === "object") {
+          const body = parsedBody as Record<string, unknown>;
+          if (typeof body.error_description === "string") {
+            message = body.error_description;
+          } else if (typeof body.message === "string") {
+            message = body.message;
+          }
+        } else if (typeof parsedBody === "string" && parsedBody.trim()) {
+          message = parsedBody.trim();
+        }
+
+        return res.status(400).send(message);
+      }
+
+      const parts = ["Соединение установлено."];
+
+      if (parsedBody && typeof parsedBody === "object") {
+        const body = parsedBody as Record<string, unknown>;
+
+        if (typeof body.access_token === "string") {
+          parts.push("Получен access_token.");
+        }
+
+        if (typeof body.expires_in === "number") {
+          parts.push(`Действует ${body.expires_in} с.`);
+        }
+
+        if (typeof body.expires_at === "string") {
+          parts.push(`Истекает ${body.expires_at}.`);
+        }
+      }
+
+      res.json({ message: parts.join(" ") });
     } catch (error) {
       if (error instanceof z.ZodError) {
         return res.status(400).json({ message: "Некорректные данные", details: error.issues });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -112,8 +112,12 @@ export const qdrantIntegrationConfigSchema = z.object({
     .min(1, "Укажите коллекцию Qdrant"),
   vectorFieldName: z.string().trim().min(1).default("vector"),
   payloadFields: z.record(z.string()).default({}),
-  vectorSize: z.number().int().positive().optional(),
-  upsertMode: z.enum(["replace", "append"]).default("replace"),
+  vectorSize: z
+    .union([z.number().int().positive(), z.string().trim().min(1)])
+    .optional(),
+  upsertMode: z
+    .union([z.enum(["replace", "append"]), z.string().trim().min(1)])
+    .default("replace"),
 });
 
 export type EmbeddingRequestConfig = z.infer<typeof embeddingRequestConfigSchema>;


### PR DESCRIPTION
## Summary
- allow Liquid templates in Qdrant integration config and update defaults to expose knowledge base data
- refresh embedding service UI with templating hints, optional header guidance, and a credential test action
- add backend endpoint to verify embedding tokens by performing the OAuth request

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d51fe3f0b8832685126dff74679c5a