### PR TITLE
Allow configuring TLS validation for embedding services

### DIFF
--- a/client/src/pages/EmbeddingServicesPage.tsx
+++ b/client/src/pages/EmbeddingServicesPage.tsx
@@ -76,6 +76,7 @@ type FormValues = {
   authorizationKey: string;
   scope: string;
   model: string;
+  allowSelfSigned: boolean;
   requestHeaders: string;
   requestConfig: string;
   responseConfig: string;
@@ -126,6 +127,7 @@ const defaultFormValues: FormValues = {
   authorizationKey: "",
   scope: "GIGACHAT_API_PERS",
   model: "embeddings",
+  allowSelfSigned: false,
   requestHeaders: formatJson(defaultRequestHeaders),
   requestConfig: formatJson(defaultRequestConfig),
   responseConfig: formatJson(defaultResponseConfig),
@@ -210,6 +212,7 @@ export default function EmbeddingServicesPage() {
       const authorizationKey = values.authorizationKey.trim();
       const scope = values.scope.trim();
       const model = values.model.trim();
+      const allowSelfSigned = values.allowSelfSigned;
 
       if (!tokenUrl) {
         const message = "Укажите endpoint для получения токена";
@@ -274,6 +277,7 @@ export default function EmbeddingServicesPage() {
         requestHeaders,
         requestConfig,
         responseConfig,
+        allowSelfSigned,
       });
 
       const result = (await response.json()) as { message?: string };
@@ -395,6 +399,7 @@ export default function EmbeddingServicesPage() {
         authorizationKey: values.authorizationKey.trim(),
         scope: values.scope.trim(),
         model: values.model.trim(),
+        allowSelfSigned: values.allowSelfSigned,
         requestHeaders,
         requestConfig,
         responseConfig,
@@ -510,6 +515,25 @@ export default function EmbeddingServicesPage() {
                         <FormLabel className="text-base">Активировать сразу</FormLabel>
                         <FormDescription>
                           Если выключить, сервис сохранится в черновиках и не будет использоваться пользователями.
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch checked={field.value} onCheckedChange={field.onChange} />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="allowSelfSigned"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                      <div className="space-y-1">
+                        <FormLabel className="text-base">Разрешить самоподписанные сертификаты</FormLabel>
+                        <FormDescription>
+                          Отключает проверку TLS-сертификата. Используйте только в доверенных сетях или при работе с
+                          корпоративными шлюзами.
                         </FormDescription>
                       </div>
                       <FormControl>
@@ -926,6 +950,14 @@ export default function EmbeddingServicesPage() {
                     <div>
                       <p className="font-medium text-foreground">Статус ключа</p>
                       <p>{provider.hasAuthorizationKey ? "Ключ сохранён" : "Ключ не задан"}</p>
+                    </div>
+                    <div>
+                      <p className="font-medium text-foreground">TLS-проверка</p>
+                      <p>
+                        {provider.allowSelfSigned
+                          ? "Проверка сертификата отключена"
+                          : "Строгая проверка сертификата"}
+                      </p>
                     </div>
                   </div>
 

--- a/migrations/0009_embedding_providers_allow_self_signed.sql
+++ b/migrations/0009_embedding_providers_allow_self_signed.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "embedding_providers"
+  ADD COLUMN IF NOT EXISTS "allow_self_signed" boolean DEFAULT false NOT NULL;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1758104593459,
       "tag": "0007_embedding_services",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1758104594459,
+      "tag": "0009_embedding_providers_allow_self_signed",
+      "breakpoints": true
     }
   ]
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,6 +2,7 @@ import type { Express, Request, Response } from "express";
 import { createServer, type Server } from "http";
 import { WebSocketServer, WebSocket } from "ws";
 import fetch, { Headers, type Response as FetchResponse } from "node-fetch";
+import https from "node:https";
 import { storage } from "./storage";
 import { crawler, type CrawlLogEvent } from "./crawler";
 import { z } from "zod";
@@ -121,6 +122,7 @@ const testEmbeddingCredentialsSchema = z.object({
   requestHeaders: z.record(z.string()).default({}),
   requestConfig: embeddingRequestConfigSchema.optional(),
   responseConfig: embeddingResponseConfigSchema.optional(),
+  allowSelfSigned: z.boolean().optional().default(false),
 });
 
 const TEST_EMBEDDING_TEXT = "привет!";
@@ -434,13 +436,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/embedding/services/test-credentials", requireAdmin, async (req, res, next) => {
     try {
       const payload = testEmbeddingCredentialsSchema.parse(req.body);
-      const requestConfig =
-        payload.requestConfig ?? embeddingRequestConfigSchema.parse(undefined);
-      const responseConfig =
-        payload.responseConfig ?? embeddingResponseConfigSchema.parse(undefined);
       const requestConfig = embeddingRequestConfigSchema.parse(payload.requestConfig ?? {});
       const responseConfig = embeddingResponseConfigSchema.parse(payload.responseConfig ?? {});
-main
+      const tlsAgent = payload.allowSelfSigned
+        ? new https.Agent({ rejectUnauthorized: false })
+        : undefined;
 
       const tokenHeaders = new Headers();
       tokenHeaders.set("Authorization", payload.authorizationKey);
@@ -457,6 +457,7 @@ main
           method: "POST",
           headers: tokenHeaders,
           body: new URLSearchParams({ scope: payload.scope }).toString(),
+          agent: tlsAgent,
         });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -487,6 +488,10 @@ main
       }
 
       const messageParts = ["Соединение установлено."];
+
+      if (payload.allowSelfSigned) {
+        messageParts.push("Проверка TLS-сертификата отключена (разрешены самоподписанные сертификаты).");
+      }
 
       let accessToken: string | undefined;
       if (parsedBody && typeof parsedBody === "object") {
@@ -527,14 +532,12 @@ main
       const embeddingBody = createEmbeddingRequestBody(requestConfig, payload.model, TEST_EMBEDDING_TEXT);
 
       let embeddingResponse: FetchResponse;
-
-      let embeddingResponse: globalThis.Response;
-main
       try {
         embeddingResponse = await fetch(payload.embeddingsUrl, {
           method: "POST",
           headers: embeddingHeaders,
           body: JSON.stringify(embeddingBody),
+          agent: tlsAgent,
         });
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
@@ -615,6 +618,7 @@ main
       if (payload.authorizationKey !== undefined) updates.authorizationKey = payload.authorizationKey;
       if (payload.scope !== undefined) updates.scope = payload.scope;
       if (payload.model !== undefined) updates.model = payload.model;
+      if (payload.allowSelfSigned !== undefined) updates.allowSelfSigned = payload.allowSelfSigned;
       if (payload.requestHeaders !== undefined) updates.requestHeaders = payload.requestHeaders;
       if (payload.requestConfig !== undefined) updates.requestConfig = payload.requestConfig;
       if (payload.responseConfig !== undefined) updates.responseConfig = payload.responseConfig;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -206,6 +206,7 @@ export const embeddingProviders = pgTable("embedding_providers", {
   authorizationKey: text("authorization_key").notNull(),
   scope: text("scope").notNull(),
   model: text("model").notNull(),
+  allowSelfSigned: boolean("allow_self_signed").notNull().default(false),
   requestHeaders: jsonb("request_headers").$type<Record<string, string>>().notNull().default(sql`'{}'::jsonb`),
   requestConfig: jsonb("request_config").$type<EmbeddingRequestConfig>().notNull().default(sql`'{}'::jsonb`),
   responseConfig: jsonb("response_config").$type<EmbeddingResponseConfig>().notNull().default(sql`'{}'::jsonb`),
@@ -312,6 +313,7 @@ export const insertEmbeddingProviderSchema = createInsertSchema(embeddingProvide
     authorizationKey: z.string().trim().min(1, "Укажите Authorization key"),
     scope: z.string().trim().min(1, "Укажите OAuth scope"),
     model: z.string().trim().min(1, "Укажите модель"),
+    allowSelfSigned: z.boolean().default(false),
     requestHeaders: z.record(z.string()).default({}),
     requestConfig: embeddingRequestConfigSchema,
     responseConfig: embeddingResponseConfigSchema,
@@ -326,6 +328,7 @@ export const updateEmbeddingProviderSchema = insertEmbeddingProviderSchema
     requestConfig: embeddingRequestConfigSchema.optional(),
     responseConfig: embeddingResponseConfigSchema.optional(),
     qdrantConfig: qdrantIntegrationConfigSchema.optional(),
+    allowSelfSigned: z.boolean().optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {
     message: "Нет данных для обновления",


### PR DESCRIPTION
## Summary
- add a flag to embedding provider schema to allow self-signed certificates and persist it in the database
- pass the flag through admin UI and backend test endpoint to disable TLS validation when needed
- show TLS status in the embedding services list and create migration for the new column

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5579cc8108326a163cc40520cc814