### PR TITLE
Handle self-signed certificates for embedding services

### DIFF
--- a/client/src/pages/EmbeddingServicesPage.tsx
+++ b/client/src/pages/EmbeddingServicesPage.tsx
@@ -76,6 +76,7 @@ type FormValues = {
   authorizationKey: string;
   scope: string;
   model: string;
+  allowSelfSignedCertificate: boolean;
   requestHeaders: string;
   requestConfig: string;
   responseConfig: string;
@@ -126,6 +127,7 @@ const defaultFormValues: FormValues = {
   authorizationKey: "",
   scope: "GIGACHAT_API_PERS",
   model: "embeddings",
+  allowSelfSignedCertificate: true,
   requestHeaders: formatJson(defaultRequestHeaders),
   requestConfig: formatJson(defaultRequestConfig),
   responseConfig: formatJson(defaultResponseConfig),
@@ -271,6 +273,7 @@ export default function EmbeddingServicesPage() {
         authorizationKey,
         scope,
         model,
+        allowSelfSignedCertificate: values.allowSelfSignedCertificate,
         requestHeaders,
         requestConfig,
         responseConfig,
@@ -395,6 +398,7 @@ export default function EmbeddingServicesPage() {
         authorizationKey: values.authorizationKey.trim(),
         scope: values.scope.trim(),
         model: values.model.trim(),
+        allowSelfSignedCertificate: values.allowSelfSignedCertificate,
         requestHeaders,
         requestConfig,
         responseConfig,
@@ -515,6 +519,26 @@ export default function EmbeddingServicesPage() {
                       <FormControl>
                         <Switch checked={field.value} onCheckedChange={field.onChange} />
                       </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="allowSelfSignedCertificate"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center justify-between rounded-lg border p-4">
+                      <div className="space-y-1 pr-4">
+                        <FormLabel className="text-base">Доверять самоподписанным сертификатам</FormLabel>
+                        <FormDescription>
+                          Отключает проверку TLS. Используйте только для доверенных провайдеров, например корпоративного API
+                          GigaChat.
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch checked={field.value} onCheckedChange={field.onChange} />
+                      </FormControl>
+                      <FormMessage />
                     </FormItem>
                   )}
                 />
@@ -926,6 +950,14 @@ export default function EmbeddingServicesPage() {
                     <div>
                       <p className="font-medium text-foreground">Статус ключа</p>
                       <p>{provider.hasAuthorizationKey ? "Ключ сохранён" : "Ключ не задан"}</p>
+                    </div>
+                    <div>
+                      <p className="font-medium text-foreground">Проверка TLS</p>
+                      <p>
+                        {provider.allowSelfSignedCertificate
+                          ? "Самоподписанные сертификаты разрешены"
+                          : "Требуется доверенный сертификат"}
+                      </p>
                     </div>
                   </div>
 

--- a/migrations/0009_embedding_providers_allow_self_signed.sql
+++ b/migrations/0009_embedding_providers_allow_self_signed.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "embedding_providers"
+  ADD COLUMN "allow_self_signed_certificate" boolean NOT NULL DEFAULT false;

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1758104593459,
       "tag": "0007_embedding_services",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1758104594459,
+      "tag": "0009_embedding_providers_allow_self_signed",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -206,6 +206,7 @@ export const embeddingProviders = pgTable("embedding_providers", {
   authorizationKey: text("authorization_key").notNull(),
   scope: text("scope").notNull(),
   model: text("model").notNull(),
+  allowSelfSignedCertificate: boolean("allow_self_signed_certificate").notNull().default(false),
   requestHeaders: jsonb("request_headers").$type<Record<string, string>>().notNull().default(sql`'{}'::jsonb`),
   requestConfig: jsonb("request_config").$type<EmbeddingRequestConfig>().notNull().default(sql`'{}'::jsonb`),
   responseConfig: jsonb("response_config").$type<EmbeddingResponseConfig>().notNull().default(sql`'{}'::jsonb`),
@@ -312,6 +313,7 @@ export const insertEmbeddingProviderSchema = createInsertSchema(embeddingProvide
     authorizationKey: z.string().trim().min(1, "Укажите Authorization key"),
     scope: z.string().trim().min(1, "Укажите OAuth scope"),
     model: z.string().trim().min(1, "Укажите модель"),
+    allowSelfSignedCertificate: z.boolean().default(false),
     requestHeaders: z.record(z.string()).default({}),
     requestConfig: embeddingRequestConfigSchema,
     responseConfig: embeddingResponseConfigSchema,
@@ -326,6 +328,7 @@ export const updateEmbeddingProviderSchema = insertEmbeddingProviderSchema
     requestConfig: embeddingRequestConfigSchema.optional(),
     responseConfig: embeddingResponseConfigSchema.optional(),
     qdrantConfig: qdrantIntegrationConfigSchema.optional(),
+    allowSelfSignedCertificate: z.boolean().optional(),
   })
   .refine((value) => Object.keys(value).length > 0, {
     message: "Нет данных для обновления",


### PR DESCRIPTION
## Summary
- add an option to trust self-signed certificates when configuring embedding providers
- update the credential test flow to reuse a custom HTTPS agent and surface clearer guidance on TLS failures
- persist the setting with a new database column and expose it in the UI

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5745f8a0483268772023e662629ce