### PR TITLE
Исправление авторизации при проверке эмбеддингового сервиса

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -462,7 +462,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const responseConfig = embeddingResponseConfigSchema.parse(payload.responseConfig ?? {});
 
       const tokenHeaders = new Headers();
-      tokenHeaders.set("Authorization", payload.authorizationKey);
+      const rawAuthorizationKey = payload.authorizationKey.trim();
+      const hasAuthScheme = /^(?:[A-Za-z]+)\s+\S+/.test(rawAuthorizationKey);
+      const authorizationHeader = hasAuthScheme
+        ? rawAuthorizationKey
+        : `Basic ${rawAuthorizationKey}`;
+      tokenHeaders.set("Authorization", authorizationHeader);
       tokenHeaders.set("Content-Type", "application/x-www-form-urlencoded");
       tokenHeaders.set("Accept", "application/json");
 


### PR DESCRIPTION
## Summary
- добавил нормализацию значения Authorization при запросе за access token, автоматически добавляя Basic, если схема не указана

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d57a6a3428832689fd484ffd3b67b6