### PR TITLE
Добавить grant_type в запрос за токеном

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -477,11 +477,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       let tokenResponse: FetchResponse;
       try {
+        const tokenRequestBody = new URLSearchParams({
+          scope: payload.scope,
+          grant_type: "client_credentials",
+        }).toString();
+
         const tokenRequestOptions = applyTlsPreferences<NodeFetchOptions>(
           {
             method: "POST",
             headers: tokenHeaders,
-            body: new URLSearchParams({ scope: payload.scope }).toString(),
+            body: tokenRequestBody,
           },
           payload.allowSelfSignedCertificate,
         );


### PR DESCRIPTION
## Summary
- добавлен параметр `grant_type=client_credentials` в запрос за OAuth-токеном при проверке настроек сервиса эмбеддингов

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d57e9e92b0832688af8a5c8cc8d81d