### PR TITLE
Добавление экспорта чанков страниц в Qdrant

### DIFF
--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -62,6 +62,13 @@
       "idx": 8,
       "version": "7",
       "when": 1758104594459,
+      "tag": "0008_embedding_providers_authorization_key",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1758104595459,
       "tag": "0009_embedding_providers_allow_self_signed",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary
- добавлено выполнение миграции 0008 в журнал Drizzle, чтобы таблица embedding_providers соответствовала схеме
- реализован серверный маршрут /api/pages/:id/vectorize с подготовкой токена, получением эмбеддингов и записью чанков страницы в Qdrant
- обновлён интерфейс страницы "Индексированные страницы" для запуска векторизации с выбором активного сервиса эмбеддингов

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d58cf7563c8326a546c3f8df4f2b24