### PR TITLE
Добавить таблицу embedding_providers в локальную схему

### DIFF
--- a/LOCAL_DATABASE_SETUP.md
+++ b/LOCAL_DATABASE_SETUP.md
@@ -145,10 +145,26 @@ curl "http://localhost:5000/api/search?q=example"
    - `frequency`, `position` (integer) - частота и позиция термина
    - `relevance` (double precision) - релевантность термина
 
-4. **users** - Пользователи (для будущих админ функций)
+4. **embedding_providers** - Настройки сервисов эмбеддингов
+   - `id` (UUID) - уникальный идентификатор сервиса
+   - `name` (text) - отображаемое название интеграции
+   - `provider_type` (text) - тип провайдера (например, `gigachat` или `custom`)
+   - `is_active` (boolean) - флаг активности сервиса
+   - `token_url` (text) - эндпоинт получения access token
+   - `embeddings_url` (text) - эндпоинт генерации эмбеддингов
+   - `authorization_key` (text) - дополнительный ключ авторизации
+   - `scope` (text) - OAuth scope
+   - `model` (text) - идентификатор модели
+   - `allow_self_signed_certificate` (boolean) - разрешение на самоподписанные сертификаты
+   - `request_headers`, `request_config`, `response_config`, `qdrant_config` (jsonb) - расширенные настройки интеграции
+
+5. **users** - Пользователи (для будущих админ функций)
    - `id` (UUID) - уникальный идентификатор
-   - `username` (text) - имя пользователя
-   - `password` (text) - хешированный пароль
+   - `email` (text) - логин пользователя
+   - `password_hash` (text) - хешированный пароль
+   - `full_name` (text) - отображаемое имя
+   - `role` (text) - роль (`admin` или `user`)
+   - `last_active_at` (timestamp) - последняя активность
 
 ### Ключевые особенности:
 

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -70,6 +70,27 @@ CREATE TABLE "search_index" (
     "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
+-- Create embedding_providers table for external embedding services configuration
+CREATE TABLE "embedding_providers" (
+    "id" varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+    "name" text NOT NULL,
+    "provider_type" text DEFAULT 'gigachat' NOT NULL,
+    "description" text,
+    "is_active" boolean DEFAULT true NOT NULL,
+    "token_url" text NOT NULL,
+    "embeddings_url" text NOT NULL,
+    "authorization_key" text DEFAULT '' NOT NULL,
+    "scope" text NOT NULL,
+    "model" text NOT NULL,
+    "allow_self_signed_certificate" boolean DEFAULT false NOT NULL,
+    "request_headers" jsonb DEFAULT '{}'::jsonb NOT NULL,
+    "request_config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+    "response_config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+    "qdrant_config" jsonb DEFAULT '{}'::jsonb NOT NULL,
+    "created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
 -- Create indexes for performance
 CREATE INDEX idx_sites_url ON sites(url);
 CREATE INDEX idx_sites_status ON sites(status);
@@ -92,6 +113,9 @@ CREATE INDEX idx_pages_content_trgm ON pages USING gin(content gin_trgm_ops);
 CREATE INDEX idx_search_index_page_id ON search_index(page_id);
 CREATE INDEX idx_search_index_term ON search_index(term);
 CREATE INDEX idx_search_index_relevance ON search_index(relevance);
+
+CREATE INDEX idx_embedding_providers_active ON embedding_providers(is_active);
+CREATE INDEX idx_embedding_providers_provider_type ON embedding_providers(provider_type);
 
 -- Triggers for automatic search vector updates
 CREATE OR REPLACE FUNCTION update_search_vectors() RETURNS TRIGGER AS $$


### PR DESCRIPTION
## Summary
- добавлена таблица embedding_providers в локальный SQL-дамп вместе с индексами
- обновлена документация по локальной базе с описанием таблицы embedding_providers и актуальными полями users

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d59d3b05d083268578afbcca6400bc