### PR TITLE
Удаление дублей в payload точек Qdrant

### DIFF
--- a/client/src/pages/PagesPage.tsx
+++ b/client/src/pages/PagesPage.tsx
@@ -149,7 +149,8 @@ function buildPayloadPreview(
   chunkCharLimit: number | null,
 ) {
   const chunkPositionRaw = chunk.metadata?.position;
-  const chunkIndex = typeof chunkPositionRaw === "number" ? chunkPositionRaw : 0;
+  const chunkPosition = typeof chunkPositionRaw === "number" ? chunkPositionRaw : 0;
+  const chunkIndex = chunkPosition;
   const chunkCharCount = chunk.metadata?.charCount ?? chunk.content.length;
   const chunkWordCount = chunk.metadata?.wordCount ?? null;
   const baseChunkId =
@@ -165,39 +166,6 @@ function buildPayloadPreview(
   const siteUrlValue = siteMetadata?.["siteUrl"];
 
   const payload = {
-    pageId: page.id,
-    pageUrl: page.url,
-    pageTitle: page.title ?? null,
-    pageMetadata: page.metadata ?? null,
-    siteId: page.siteId,
-    siteName: typeof siteNameValue === "string" ? siteNameValue : null,
-    siteUrl: typeof siteUrlValue === "string" ? siteUrlValue : null,
-    providerId: provider?.id ?? null,
-    providerName: provider?.name ?? null,
-    providerModel: provider?.model ?? null,
-    totalChunks,
-    chunkCharLimit,
-    chunkId: baseChunkId,
-    chunkIndex,
-    chunkHeading: chunk.heading ?? null,
-    chunkLevel: chunk.level ?? null,
-    chunkDeepLink: chunk.deepLink ?? null,
-    chunkText: chunk.content,
-    chunkCharCount,
-    chunkWordCount,
-    chunkPosition: chunkIndex,
-    chunkExcerpt: chunk.metadata?.excerpt ?? null,
-    chunk: {
-      id: baseChunkId,
-      index: chunkIndex,
-      heading: chunk.heading ?? null,
-      level: chunk.level ?? null,
-      deepLink: chunk.deepLink ?? null,
-      text: chunk.content,
-      charCount: chunkCharCount,
-      wordCount: chunkWordCount,
-      metadata: chunk.metadata ?? null,
-    },
     page: {
       id: page.id,
       url: page.url,
@@ -206,14 +174,28 @@ function buildPayloadPreview(
       chunkCharLimit,
       metadata: page.metadata ?? null,
     },
-    site:
-      typeof siteNameValue === "string" || typeof siteUrlValue === "string"
-        ? {
-            id: page.siteId,
-            name: typeof siteNameValue === "string" ? siteNameValue : null,
-            url: typeof siteUrlValue === "string" ? siteUrlValue : null,
-          }
-        : null,
+    site: {
+      id: page.siteId,
+      name: typeof siteNameValue === "string" ? siteNameValue : null,
+      url: typeof siteUrlValue === "string" ? siteUrlValue : null,
+    },
+    provider: {
+      id: provider?.id ?? null,
+      name: provider?.name ?? null,
+    },
+    chunk: {
+      id: baseChunkId,
+      index: chunkIndex,
+      position: chunkPosition,
+      heading: chunk.heading ?? null,
+      level: chunk.level ?? null,
+      deepLink: chunk.deepLink ?? null,
+      text: chunk.content,
+      charCount: chunkCharCount,
+      wordCount: chunkWordCount,
+      excerpt: chunk.metadata?.excerpt ?? null,
+      metadata: chunk.metadata ?? null,
+    },
     embedding: {
       model: provider?.model ?? null,
       vectorSize:

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2076,41 +2076,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const chunkCharCount = chunk.metadata?.charCount ?? chunk.content.length;
         const chunkWordCount = chunk.metadata?.wordCount ?? null;
         const chunkPosition = chunk.metadata?.position ?? index;
+        const chunkExcerpt = chunk.metadata?.excerpt ?? null;
 
         const rawPayload = {
-          pageId: page.id,
-          pageUrl: page.url,
-          pageTitle: page.title ?? null,
-          pageMetadata: page.metadata ?? null,
-          siteId: page.siteId,
-          siteName: site?.name ?? null,
-          siteUrl: site?.url ?? null,
-          providerId: provider.id,
-          providerName: provider.name,
-          providerModel: provider.model,
-          totalChunks,
-          chunkCharLimit,
-          chunkId: baseChunkId,
-          chunkIndex: index,
-          chunkHeading: chunk.heading ?? null,
-          chunkLevel: chunk.level ?? null,
-          chunkDeepLink: chunk.deepLink ?? null,
-          chunkText: chunk.content,
-          chunkCharCount,
-          chunkWordCount,
-          chunkPosition,
-          chunkExcerpt: chunk.metadata?.excerpt ?? null,
-          chunk: {
-            id: baseChunkId,
-            index,
-            heading: chunk.heading ?? null,
-            level: chunk.level ?? null,
-            deepLink: chunk.deepLink ?? null,
-            text: chunk.content,
-            charCount: chunkCharCount,
-            wordCount: chunkWordCount,
-            metadata: chunk.metadata ?? null,
-          },
           page: {
             id: page.id,
             url: page.url,
@@ -2119,13 +2087,28 @@ export async function registerRoutes(app: Express): Promise<Server> {
             chunkCharLimit,
             metadata: page.metadata ?? null,
           },
-          site: site
-            ? {
-                id: site.id,
-                name: site.name,
-                url: site.url,
-              }
-            : null,
+          site: {
+            id: page.siteId,
+            name: site?.name ?? null,
+            url: site?.url ?? null,
+          },
+          provider: {
+            id: provider.id,
+            name: provider.name,
+          },
+          chunk: {
+            id: baseChunkId,
+            index,
+            position: chunkPosition,
+            heading: chunk.heading ?? null,
+            level: chunk.level ?? null,
+            deepLink: chunk.deepLink ?? null,
+            text: chunk.content,
+            charCount: chunkCharCount,
+            wordCount: chunkWordCount,
+            excerpt: chunkExcerpt,
+            metadata: chunk.metadata ?? null,
+          },
           embedding: {
             model: provider.model,
             vectorSize: vector.length,


### PR DESCRIPTION
## Summary
- сократил состав payload при записи чанков в Qdrant, оставив только уникальные поля
- обновил предпросмотр payload на клиенте, чтобы он соответствовал новой структуре

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d684470b4c8326b14047f3ff47908f