### PR TITLE
feat: allow fullscreen vector record preview

### DIFF
--- a/client/src/components/ui/sheet.tsx
+++ b/client/src/components/ui/sheet.tsx
@@ -38,13 +38,20 @@ const sheetVariants = cva(
         top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
           "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        left: "inset-y-0 left-0 h-full border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+      },
+      size: {
+        default: "w-3/4 sm:max-w-sm",
+        lg: "w-full sm:max-w-lg md:max-w-xl",
+        xl: "w-full sm:max-w-2xl md:max-w-3xl lg:max-w-4xl xl:max-w-6xl",
+        fullscreen: "w-screen max-w-none sm:max-w-none",
       },
     },
     defaultVariants: {
       side: "right",
+      size: "default",
     },
   }
 )
@@ -56,12 +63,12 @@ interface SheetContentProps
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", size, className, children, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
       ref={ref}
-      className={cn(sheetVariants({ side }), className)}
+      className={cn(sheetVariants({ side, size }), className)}
       {...props}
     >
       {children}

--- a/client/src/pages/VectorCollectionDetailPage.tsx
+++ b/client/src/pages/VectorCollectionDetailPage.tsx
@@ -480,10 +480,8 @@ export default function VectorCollectionDetailPage() {
       >
         <SheetContent
           side="right"
-          className={cn(
-            "flex w-full flex-col gap-4",
-            isPointPreviewFullScreen ? "max-w-[95vw]" : "max-w-6xl",
-          )}
+          size={isPointPreviewFullScreen ? "fullscreen" : "xl"}
+          className="flex h-full flex-col gap-4"
         >
           <SheetHeader className="space-y-3">
             <div className="flex flex-wrap items-start justify-between gap-3">


### PR DESCRIPTION
## Summary
- add configurable size variants to the sheet component so drawers can expand wider or to fullscreen
- update the vector collection record viewer to use the new sizes for normal and fullscreen modes

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d6d42dbeec832692e7bbc24d10cfad