### PR TITLE
Добавлен публичный API поиска и документация

### DIFF
--- a/migrations/0010_sites_public_api.sql
+++ b/migrations/0010_sites_public_api.sql
@@ -1,0 +1,20 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+ALTER TABLE "sites" ADD COLUMN "public_id" varchar;
+ALTER TABLE "sites" ADD COLUMN "public_api_key" text DEFAULT encode(gen_random_bytes(32), 'hex');
+ALTER TABLE "sites" ADD COLUMN "public_api_key_generated_at" timestamp DEFAULT CURRENT_TIMESTAMP;
+
+UPDATE "sites"
+SET
+  "public_id" = COALESCE("public_id", gen_random_uuid()),
+  "public_api_key" = COALESCE("public_api_key", encode(gen_random_bytes(32), 'hex')),
+  "public_api_key_generated_at" = COALESCE("public_api_key_generated_at", CURRENT_TIMESTAMP);
+
+ALTER TABLE "sites" ALTER COLUMN "public_id" SET NOT NULL;
+ALTER TABLE "sites" ALTER COLUMN "public_api_key" SET NOT NULL;
+ALTER TABLE "sites" ALTER COLUMN "public_api_key_generated_at" SET NOT NULL;
+
+ALTER TABLE "sites" ALTER COLUMN "public_id" SET DEFAULT gen_random_uuid();
+ALTER TABLE "sites" ALTER COLUMN "public_api_key" SET DEFAULT encode(gen_random_bytes(32), 'hex');
+
+ALTER TABLE "sites" ADD CONSTRAINT "sites_public_id_unique" UNIQUE("public_id");

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1758104595459,
       "tag": "0009_embedding_providers_allow_self_signed",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1758104596459,
+      "tag": "0010_sites_public_api",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -182,6 +182,16 @@ export const sites = pgTable("sites", {
   ownerId: varchar("owner_id")
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),
+  publicId: varchar("public_id")
+    .notNull()
+    .unique()
+    .default(sql`gen_random_uuid()`),
+  publicApiKey: text("public_api_key")
+    .notNull()
+    .default(sql`encode(gen_random_bytes(32), 'hex')`),
+  publicApiKeyGeneratedAt: timestamp("public_api_key_generated_at")
+    .default(sql`CURRENT_TIMESTAMP`)
+    .notNull(),
 });
 
 // Pages table for storing crawled page content


### PR DESCRIPTION
## Summary
- добавлены публичные поля коллекций и миграция для выдачи открытого API-ключа
- реализован публичный endpoint поиска и возможность ротировать ключи коллекций
- обновлена страница "Документация API" с инструкциями и примерами использования нового API

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d7c378ed9c8326ab02c4cffcbb4898