### PR TITLE
feat: поддержка управления персональными API токенами

### DIFF
--- a/client/src/pages/ProfilePage.tsx
+++ b/client/src/pages/ProfilePage.tsx
@@ -9,7 +9,8 @@ import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
-import { Loader2, Check, Copy, UserSquare2, KeyRound, Shield } from "lucide-react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Loader2, Check, Copy, UserSquare2, KeyRound, Shield, ChevronDown, ChevronUp, History, Trash2 } from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import type { PublicUser } from "@shared/schema";
@@ -29,9 +30,26 @@ interface ChangePasswordPayload {
   newPassword: string;
 }
 
+interface PersonalApiTokenSummary {
+  id: string;
+  lastFour: string;
+  createdAt: string;
+  revokedAt: string | null;
+}
+
+interface PersonalApiTokensResponse {
+  tokens: PersonalApiTokenSummary[];
+}
+
 interface IssueTokenResponse {
   token: string;
   user: PublicUser;
+  tokens: PersonalApiTokenSummary[];
+}
+
+interface RevokeTokenResponse {
+  user: PublicUser;
+  tokens: PersonalApiTokenSummary[];
 }
 
 interface PasswordFormValues {
@@ -67,6 +85,13 @@ export default function ProfilePage() {
   const { data, isLoading, error } = useQuery<UserResponse>({
     queryKey: ["/api/users/me"],
   });
+  const {
+    data: tokensData,
+    isLoading: areTokensLoading,
+    error: tokensError,
+  } = useQuery<PersonalApiTokensResponse>({
+    queryKey: ["/api/users/me/api-tokens"],
+  });
 
   const profileForm = useForm<ProfileFormValues>({
     defaultValues: {
@@ -85,8 +110,12 @@ export default function ProfilePage() {
 
   const [issuedToken, setIssuedToken] = useState<string | null>(null);
   const [isCopied, setIsCopied] = useState(false);
+  const [showRevokedTokens, setShowRevokedTokens] = useState(false);
 
   const user = data?.user;
+  const tokens = tokensData?.tokens ?? [];
+  const activeTokens = useMemo(() => tokens.filter((token) => !token.revokedAt), [tokens]);
+  const revokedTokens = useMemo(() => tokens.filter((token) => Boolean(token.revokedAt)), [tokens]);
 
   useEffect(() => {
     if (user) {
@@ -98,6 +127,12 @@ export default function ProfilePage() {
       setIssuedToken(null);
     }
   }, [user, profileForm]);
+
+  useEffect(() => {
+    if (revokedTokens.length === 0) {
+      setShowRevokedTokens(false);
+    }
+  }, [revokedTokens.length]);
 
   const updateProfileMutation = useMutation({
     mutationFn: async (values: ProfileFormValues) => {
@@ -150,25 +185,80 @@ export default function ProfilePage() {
     },
   });
 
-  const issueTokenMutation = useMutation({
+  const issueTokenMutation = useMutation<IssueTokenResponse, unknown, void>({
     mutationFn: async () => {
-      const response = await apiRequest("POST", "/api/users/me/api-token");
+      const response = await apiRequest("POST", "/api/users/me/api-tokens");
       return (await response.json()) as IssueTokenResponse;
     },
-    onSuccess: (result) => {
-      setIssuedToken(result.token);
-      setIsCopied(false);
+    onSuccess: async (result) => {
+      queryClient.setQueryData(["/api/users/me/api-tokens"], { tokens: result.tokens });
       queryClient.setQueryData(["/api/users/me"], { user: result.user });
       queryClient.setQueryData<{ user: PublicUser } | null>(["/api/auth/session"], (prev) =>
         prev ? { ...prev, user: result.user } : prev,
       );
+
+      setIssuedToken(result.token);
+
+      let autoCopyMessage: string | null = null;
+      let isAutoCopied = false;
+
+      if (typeof navigator !== "undefined" && navigator.clipboard && navigator.clipboard.writeText) {
+        try {
+          await navigator.clipboard.writeText(result.token);
+          isAutoCopied = true;
+        } catch (copyError) {
+          autoCopyMessage = copyError instanceof Error ? copyError.message : "Не удалось скопировать токен";
+        }
+      } else {
+        autoCopyMessage = "Буфер обмена недоступен";
+      }
+
+      setIsCopied(isAutoCopied);
+
       toast({
         title: "Токен выпущен",
-        description: "Сохраните значение — оно отображается только один раз",
+        description: isAutoCopied
+          ? "Значение автоматически скопировано в буфер обмена"
+          : "Сохраните значение — токен отображается только один раз",
       });
+
+      if (autoCopyMessage && !isAutoCopied) {
+        toast({
+          title: "Не удалось автоматически скопировать токен",
+          description: autoCopyMessage,
+          variant: "destructive",
+        });
+      }
     },
     onError: (mutationError: unknown) => {
       const message = mutationError instanceof Error ? mutationError.message : "Не удалось выпустить токен";
+      toast({
+        title: "Ошибка",
+        description: message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  const revokeTokenMutation = useMutation<RevokeTokenResponse, unknown, string>({
+    mutationFn: async (tokenId: string) => {
+      const response = await apiRequest("POST", `/api/users/me/api-tokens/${tokenId}/revoke`);
+      return (await response.json()) as RevokeTokenResponse;
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData(["/api/users/me/api-tokens"], { tokens: result.tokens });
+      queryClient.setQueryData(["/api/users/me"], { user: result.user });
+      queryClient.setQueryData<{ user: PublicUser } | null>(["/api/auth/session"], (prev) =>
+        prev ? { ...prev, user: result.user } : prev,
+      );
+
+      toast({
+        title: "Токен отозван",
+        description: "Доступ по токену будет прекращён в ближайшее время",
+      });
+    },
+    onError: (mutationError: unknown) => {
+      const message = mutationError instanceof Error ? mutationError.message : "Не удалось отозвать токен";
       toast({
         title: "Ошибка",
         description: message,
@@ -193,16 +283,24 @@ export default function ProfilePage() {
   };
 
   const tokenMetadata = useMemo(() => {
-    if (!user) {
-      return { hasToken: false, lastFour: null as string | null, generatedAt: null as string | Date | null };
+    if (!tokensData && user) {
+      return {
+        hasToken: user.hasPersonalApiToken,
+        lastFour: user.personalApiTokenLastFour,
+        generatedAt: user.personalApiTokenGeneratedAt ?? null,
+        activeCount: user.hasPersonalApiToken ? 1 : 0,
+      };
     }
 
+    const latestActive = activeTokens.length > 0 ? activeTokens[0] : null;
+
     return {
-      hasToken: user.hasPersonalApiToken,
-      lastFour: user.personalApiTokenLastFour,
-      generatedAt: user.personalApiTokenGeneratedAt ?? null,
+      hasToken: activeTokens.length > 0,
+      lastFour: latestActive ? latestActive.lastFour : null,
+      generatedAt: latestActive ? latestActive.createdAt : null,
+      activeCount: activeTokens.length,
     };
-  }, [user]);
+  }, [activeTokens, tokensData, user]);
 
   if (isLoading) {
     return (
@@ -406,7 +504,9 @@ export default function ProfilePage() {
               <div className="flex flex-wrap items-center gap-3 text-sm">
                 <Badge variant={tokenMetadata.hasToken ? "default" : "secondary"} className="flex items-center gap-1">
                   {tokenMetadata.hasToken ? <Check className="h-3.5 w-3.5" /> : <KeyRound className="h-3.5 w-3.5" />}
-                  {tokenMetadata.hasToken ? "Токен активен" : "Токен не выпущен"}
+                  {tokenMetadata.hasToken
+                    ? `Активных токенов: ${tokenMetadata.activeCount}`
+                    : "Активных токенов нет"}
                 </Badge>
                 <span className="text-muted-foreground">
                   Последнее обновление: {formatTokenDate(tokenMetadata.generatedAt)}
@@ -416,7 +516,7 @@ export default function ProfilePage() {
 
               <Separator />
 
-              {issuedToken ? (
+              {issuedToken && (
                 <Alert>
                   <AlertTitle>Новый токен</AlertTitle>
                   <AlertDescription>
@@ -439,11 +539,94 @@ export default function ProfilePage() {
                     </p>
                   </AlertDescription>
                 </Alert>
+              )}
+
+              {tokensError ? (
+                <Alert variant="destructive">
+                  <AlertTitle>Не удалось загрузить токены</AlertTitle>
+                  <AlertDescription>
+                    {tokensError instanceof Error
+                      ? tokensError.message
+                      : "Попробуйте обновить страницу чуть позже"}
+                  </AlertDescription>
+                </Alert>
+              ) : areTokensLoading ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Загружаем список токенов...
+                </div>
               ) : (
-                <p className="text-sm text-muted-foreground">
-                  Нажмите кнопку ниже, чтобы сгенерировать персональный токен. Его можно использовать в сценариях интеграции и
-                  векторного поиска.
-                </p>
+                <>
+                  {activeTokens.length > 0 ? (
+                    <ul className="space-y-3">
+                      {activeTokens.map((token) => {
+                        const isRevoking =
+                          revokeTokenMutation.isPending && revokeTokenMutation.variables === token.id;
+                        return (
+                          <li key={token.id} className="rounded-md border bg-muted/20 p-3">
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                              <div className="space-y-1 text-sm">
+                                <div className="font-medium">Последние символы {token.lastFour}</div>
+                                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                                  <History className="h-3.5 w-3.5" /> Выпущен: {formatTokenDate(token.createdAt)}
+                                </div>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => revokeTokenMutation.mutate(token.id)}
+                                  disabled={isRevoking}
+                                >
+                                  {isRevoking ? (
+                                    <>
+                                      <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Отзываем...
+                                    </>
+                                  ) : (
+                                    <>
+                                      <Trash2 className="mr-2 h-4 w-4" /> Отозвать
+                                    </>
+                                  )}
+                                </Button>
+                              </div>
+                            </div>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  ) : !issuedToken ? (
+                    <p className="text-sm text-muted-foreground">
+                      Нажмите кнопку ниже, чтобы сгенерировать персональный токен. Его можно использовать в сценариях
+                      интеграции и векторного поиска.
+                    </p>
+                  ) : null}
+
+                  {revokedTokens.length > 0 && (
+                    <Collapsible open={showRevokedTokens} onOpenChange={setShowRevokedTokens}>
+                      <CollapsibleTrigger asChild>
+                        <Button variant="ghost" size="sm" className="flex items-center gap-2 px-0">
+                          {showRevokedTokens ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+                          Отозванные токены ({revokedTokens.length})
+                        </Button>
+                      </CollapsibleTrigger>
+                      <CollapsibleContent className="mt-3 space-y-2">
+                        {revokedTokens.map((token) => (
+                          <div key={token.id} className="rounded-md border border-dashed bg-muted/10 p-3 text-sm">
+                            <div className="font-medium text-muted-foreground">Последние символы {token.lastFour}</div>
+                            <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                              <span className="flex items-center gap-1">
+                                <History className="h-3.5 w-3.5" /> Выпущен: {formatTokenDate(token.createdAt)}
+                              </span>
+                              <span className="flex items-center gap-1">
+                                <Shield className="h-3.5 w-3.5" /> Отозван: {formatTokenDate(token.revokedAt ?? null)}
+                              </span>
+                            </div>
+                          </div>
+                        ))}
+                      </CollapsibleContent>
+                    </Collapsible>
+                  )}
+                </>
               )}
 
               <Button type="button" onClick={() => issueTokenMutation.mutate()} disabled={issueTokenMutation.isPending}>

--- a/database_schema.sql
+++ b/database_schema.sql
@@ -17,6 +17,15 @@ CREATE TABLE "users" (
     "updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
+CREATE TABLE "personal_api_tokens" (
+    "id" varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+    "user_id" varchar NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+    "token_hash" text NOT NULL,
+    "last_four" text NOT NULL,
+    "created_at" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revoked_at" timestamp
+);
+
 -- Create sites table for storing crawl configurations
 CREATE TABLE "sites" (
     "id" varchar PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -116,6 +125,9 @@ CREATE INDEX idx_search_index_relevance ON search_index(relevance);
 
 CREATE INDEX idx_embedding_providers_active ON embedding_providers(is_active);
 CREATE INDEX idx_embedding_providers_provider_type ON embedding_providers(provider_type);
+
+CREATE INDEX personal_api_tokens_user_id_idx ON personal_api_tokens(user_id);
+CREATE INDEX personal_api_tokens_active_idx ON personal_api_tokens(user_id) WHERE revoked_at IS NULL;
 
 -- Triggers for automatic search vector updates
 CREATE OR REPLACE FUNCTION update_search_vectors() RETURNS TRIGGER AS $$

--- a/migrations/0012_personal_api_tokens.sql
+++ b/migrations/0012_personal_api_tokens.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS "personal_api_tokens" (
+  "id" varchar PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id" varchar NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "token_hash" text NOT NULL,
+  "last_four" text NOT NULL,
+  "created_at" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "revoked_at" timestamp
+);
+
+CREATE INDEX IF NOT EXISTS "personal_api_tokens_user_id_idx" ON "personal_api_tokens" ("user_id");
+CREATE INDEX IF NOT EXISTS "personal_api_tokens_active_idx" ON "personal_api_tokens" ("user_id") WHERE "revoked_at" IS NULL;
+
+INSERT INTO "personal_api_tokens" ("user_id", "token_hash", "last_four", "created_at")
+SELECT "id", "personal_api_token_hash", COALESCE("personal_api_token_last_four", ''),
+       COALESCE("personal_api_token_generated_at", CURRENT_TIMESTAMP)
+FROM "users"
+WHERE COALESCE(NULLIF("personal_api_token_hash", ''), '') <> ''
+  AND NOT EXISTS (
+    SELECT 1 FROM "personal_api_tokens" existing
+    WHERE existing."user_id" = "users"."id"
+      AND existing."token_hash" = "users"."personal_api_token_hash"
+  );

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1758104597459,
       "tag": "0011_user_profile_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1758104598459,
+      "tag": "0012_personal_api_tokens",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -77,6 +77,17 @@ export const users = pgTable("users", {
   personalApiTokenGeneratedAt: timestamp("personal_api_token_generated_at"),
 });
 
+export const personalApiTokens = pgTable("personal_api_tokens", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  tokenHash: text("token_hash").notNull(),
+  lastFour: text("last_four").notNull(),
+  createdAt: timestamp("created_at").notNull().default(sql`CURRENT_TIMESTAMP`),
+  revokedAt: timestamp("revoked_at"),
+});
+
 export const insertUserSchema = createInsertSchema(users).omit({
   id: true,
   role: true,
@@ -417,6 +428,9 @@ export type PublicUser = Omit<
   hasPersonalApiToken: boolean;
   personalApiTokenLastFour: string | null;
 };
+export type PersonalApiToken = typeof personalApiTokens.$inferSelect;
+export type InsertPersonalApiToken = typeof personalApiTokens.$inferInsert;
+export type PublicPersonalApiToken = Omit<PersonalApiToken, "tokenHash" | "userId">;
 export type EmbeddingProvider = typeof embeddingProviders.$inferSelect;
 export type EmbeddingProviderInsert = typeof embeddingProviders.$inferInsert;
 export type InsertEmbeddingProvider = z.infer<typeof insertEmbeddingProviderSchema>;


### PR DESCRIPTION
## Summary
- добавить таблицу и API для хранения нескольких персональных токенов и их отзыва
- обновить страницу профиля: автокопирование нового токена, список активных и отозванных токенов, кнопка отзыва
- синхронизировать схему базы, миграции и отображение данных пользователя с новым функционалом

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d959f0fd248326aa04224b3d05de9f