### PR TITLE
Handle Qdrant search errors

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2429,6 +2429,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
         });
       }
 
+      const qdrantError = extractQdrantApiError(error);
+      if (qdrantError) {
+        console.error(`Ошибка Qdrant при поиске в коллекции ${req.params.name}:`, error);
+        return res.status(qdrantError.status).json({
+          error: qdrantError.message,
+          details: qdrantError.details,
+        });
+      }
+
       console.error(`Ошибка при поиске в коллекции ${req.params.name}:`, error);
       res.status(500).json({
         error: "Не удалось выполнить поиск",


### PR DESCRIPTION
## Summary
- return Qdrant error details from the vector search endpoint instead of a generic 500
- log Qdrant search failures for easier diagnostics

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dad7d2d2d08326a9b18611841f5fab