### PR TITLE
Fix Google OAuth availability detection

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1313,7 +1313,7 @@ function buildExcerpt(content: string | null | undefined, query: string, maxLeng
 }
 
 export async function registerRoutes(app: Express): Promise<Server> {
-  const googleAuthEnabled = Boolean(app.get("googleAuthConfigured"));
+  const isGoogleAuthEnabled = () => Boolean(app.get("googleAuthConfigured"));
 
   app.post("/api/public/collections/:publicId/search", async (req, res) => {
     try {
@@ -1467,6 +1467,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.get("/api/auth/providers", (_req, res) => {
+    const googleAuthEnabled = isGoogleAuthEnabled();
     res.json({
       providers: {
         local: { enabled: true },
@@ -1495,6 +1496,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.get("/api/auth/google", (req, res, next) => {
+    const googleAuthEnabled = isGoogleAuthEnabled();
     if (!googleAuthEnabled) {
       res.status(404).json({ message: "Авторизация через Google недоступна" });
       return;
@@ -1514,6 +1516,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   app.get("/api/auth/google/callback", (req, res, next) => {
+    const googleAuthEnabled = isGoogleAuthEnabled();
     if (!googleAuthEnabled) {
       res.status(404).json({ message: "Авторизация через Google недоступна" });
       return;


### PR DESCRIPTION
## Summary
- read the Google OAuth enabled flag from the Express app at request time so the latest settings are used

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e533d9d8388326be7abeb9dda249e1