### PR TITLE
Добавлена поддержка Yandex OAuth

### DIFF
--- a/migrations/0015_yandex_auth.sql
+++ b/migrations/0015_yandex_auth.sql
@@ -1,0 +1,28 @@
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "yandex_id" text;
+
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "yandex_avatar" text DEFAULT '';
+
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "yandex_email_verified" boolean DEFAULT FALSE;
+
+UPDATE "users"
+SET
+  "yandex_avatar" = COALESCE("yandex_avatar", ''),
+  "yandex_email_verified" = COALESCE("yandex_email_verified", FALSE);
+
+ALTER TABLE "users"
+  ALTER COLUMN "yandex_avatar" SET DEFAULT '';
+
+ALTER TABLE "users"
+  ALTER COLUMN "yandex_avatar" SET NOT NULL;
+
+ALTER TABLE "users"
+  ALTER COLUMN "yandex_email_verified" SET DEFAULT FALSE;
+
+ALTER TABLE "users"
+  ALTER COLUMN "yandex_email_verified" SET NOT NULL;
+
+ALTER TABLE "users"
+  ADD CONSTRAINT IF NOT EXISTS "users_yandex_id_unique" UNIQUE ("yandex_id");

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-local": "^1.0.0",
+        "passport-yandex": "^0.0.5",
         "pdfjs-dist": "^4.10.38",
         "pg": "^8.16.3",
         "puppeteer": "^22.15.0",
@@ -9954,6 +9955,42 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/passport-oauth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz",
+      "integrity": "sha512-4IZNVsZbN1dkBzmEbBqUxDG8oFOIK81jqdksE3HEb/vI3ib3FMjbiZZ6MTtooyYZzmKu0BfovjvT1pdGgIq+4Q==",
+      "dependencies": {
+        "passport-oauth1": "1.x.x",
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth1": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.3.0.tgz",
+      "integrity": "sha512-8T/nX4gwKTw0PjxP1xfD0QhrydQNakzeOpZ6M5Uqdgz9/a/Ag62RmJxnZQ4LkbdXGrRehQHIAHNAu11rCP46Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-oauth1/node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
     "node_modules/passport-oauth2": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
@@ -9980,6 +10017,19 @@
       "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-yandex": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/passport-yandex/-/passport-yandex-0.0.5.tgz",
+      "integrity": "sha512-zw0JR2jLrPGhF7eAzVJb7CvAd8Uacy7dSckzt0bzonTBDbsWx2wdmVDa11Kg4fDLirHkQF72nM0ijDs8oKdO3A==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth": "1.0.x",
+        "pkginfo": "0.3.x"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -10196,6 +10246,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-local": "^1.0.0",
+    "passport-yandex": "^0.0.5",
     "pdfjs-dist": "^4.10.38",
     "pg": "^8.16.3",
     "puppeteer": "^22.15.0",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -78,6 +78,9 @@ export const users = pgTable("users", {
   googleId: text("google_id").unique(),
   googleAvatar: text("google_avatar").notNull().default(""),
   googleEmailVerified: boolean("google_email_verified").notNull().default(false),
+  yandexId: text("yandex_id").unique(),
+  yandexAvatar: text("yandex_avatar").notNull().default(""),
+  yandexEmailVerified: boolean("yandex_email_verified").notNull().default(false),
 });
 
 export const personalApiTokens = pgTable("personal_api_tokens", {
@@ -113,12 +116,14 @@ export const insertUserSchema = createInsertSchema(users).omit({
   personalApiTokenGeneratedAt: true,
   googleAvatar: true,
   googleEmailVerified: true,
+  yandexAvatar: true,
+  yandexEmailVerified: true,
 });
 
 export const embeddingProviderTypes = ["gigachat", "custom"] as const;
 export type EmbeddingProviderType = (typeof embeddingProviderTypes)[number];
 
-export const authProviderTypes = ["google"] as const;
+export const authProviderTypes = ["google", "yandex"] as const;
 export type AuthProviderType = (typeof authProviderTypes)[number];
 
 export const embeddingRequestConfigSchema = z

--- a/types/passport-yandex.d.ts
+++ b/types/passport-yandex.d.ts
@@ -1,0 +1,54 @@
+declare module "passport-yandex" {
+  import type { Strategy as PassportStrategy } from "passport";
+
+  export interface YandexProfile extends Record<string, unknown> {
+    id: string;
+    displayName?: string;
+    name?: {
+      familyName?: string;
+      givenName?: string;
+      middleName?: string;
+    };
+    emails?: Array<{ value?: string; type?: string }>;
+    photos?: Array<{ value?: string }>;
+    _json?: {
+      id?: string;
+      default_email?: string;
+      emails?: Array<{ value?: string; default?: boolean; primary?: boolean }>;
+      real_name?: string;
+      first_name?: string;
+      last_name?: string;
+      display_name?: string;
+      is_avatar_empty?: boolean;
+      default_avatar_id?: string;
+      is_email_verified?: boolean;
+      default_phone?: { number?: string };
+    } & Record<string, unknown>;
+  }
+
+  export interface StrategyOptions {
+    clientID: string;
+    clientSecret: string;
+    callbackURL: string;
+  }
+
+  export type VerifyCallback = (
+    err?: Error | null,
+    user?: Express.User | false,
+    info?: unknown,
+  ) => void;
+
+  export interface VerifyFunction {
+    (
+      accessToken: string,
+      refreshToken: string,
+      profile: YandexProfile,
+      done: VerifyCallback,
+    ): void;
+  }
+
+  export class Strategy extends PassportStrategy {
+    constructor(options: StrategyOptions, verify: VerifyFunction);
+    name: "yandex";
+  }
+}


### PR DESCRIPTION
## Summary
- добавлен OAuth-провайдер Yandex вместе с миграцией базы и типами
- расширен API и UI для управления настройками Google и Yandex и отображения кнопок входа
- обновлены серверные стратегии аутентификации и обработка пользователей для нового провайдера

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e547ad6cd08326b0baf198c4b6b049