### PR TITLE
Добавление привязки коллекций и страниц к рабочему пространству

### DIFF
--- a/migrations/0018_workspace_collections_and_page_ownership.sql
+++ b/migrations/0018_workspace_collections_and_page_ownership.sql
@@ -1,0 +1,117 @@
+DO $$
+BEGIN
+  CREATE TABLE IF NOT EXISTS "workspace_vector_collections" (
+    "collection_name" text PRIMARY KEY,
+    "workspace_id" varchar NOT NULL,
+    "created_at" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+  );
+EXCEPTION
+  WHEN duplicate_table THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  ALTER TABLE "workspace_vector_collections"
+    ADD CONSTRAINT "workspace_vector_collections_workspace_id_fkey"
+    FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "workspace_vector_collections_workspace_id_idx"
+  ON "workspace_vector_collections" ("workspace_id");
+
+WITH target_user AS (
+  SELECT id
+  FROM "users"
+  WHERE email = 'forlandeivan@gmail.com'
+  LIMIT 1
+),
+final_workspace AS (
+  SELECT w.id
+  FROM "workspaces" w
+  JOIN target_user tu ON w.owner_id = tu.id
+  WHERE w.name = 'forlandeivan'
+  ORDER BY w.created_at
+  LIMIT 1
+),
+collection_names AS (
+  SELECT unnest(ARRAY[
+    'test_final',
+    'проверочная коллекция 23.09',
+    'kb11111111111',
+    'newcollection',
+    'МОЭК',
+    'newcollection222222222',
+    'monq_docs',
+    'fr_test'
+  ]) AS collection_name
+)
+INSERT INTO "workspace_vector_collections" ("collection_name", "workspace_id")
+SELECT cn.collection_name, fw.id
+FROM collection_names cn
+CROSS JOIN final_workspace fw
+ON CONFLICT ("collection_name") DO UPDATE
+SET "workspace_id" = EXCLUDED."workspace_id",
+    "updated_at" = CURRENT_TIMESTAMP;
+
+ALTER TABLE "pages"
+  ADD COLUMN IF NOT EXISTS "workspace_id" varchar;
+
+WITH page_workspaces AS (
+  SELECT p.id, s.workspace_id
+  FROM "pages" p
+  JOIN "sites" s ON s.id = p.site_id
+)
+UPDATE "pages" p
+SET "workspace_id" = pw.workspace_id,
+    "updated_at" = CURRENT_TIMESTAMP
+FROM page_workspaces pw
+WHERE p.id = pw.id
+  AND (p.workspace_id IS DISTINCT FROM pw.workspace_id);
+
+ALTER TABLE "pages"
+  ALTER COLUMN "workspace_id" SET NOT NULL;
+
+DO $$
+BEGIN
+  ALTER TABLE "pages"
+    ADD CONSTRAINT "pages_workspace_id_fkey"
+    FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "pages_workspace_id_idx"
+  ON "pages" ("workspace_id");
+
+ALTER TABLE "search_index"
+  ADD COLUMN IF NOT EXISTS "workspace_id" varchar;
+
+WITH search_workspaces AS (
+  SELECT si.id, s.workspace_id
+  FROM "search_index" si
+  JOIN "pages" p ON p.id = si.page_id
+  JOIN "sites" s ON s.id = p.site_id
+)
+UPDATE "search_index" si
+SET "workspace_id" = sw.workspace_id
+FROM search_workspaces sw
+WHERE si.id = sw.id
+  AND (si.workspace_id IS DISTINCT FROM sw.workspace_id);
+
+ALTER TABLE "search_index"
+  ALTER COLUMN "workspace_id" SET NOT NULL;
+
+DO $$
+BEGIN
+  ALTER TABLE "search_index"
+    ADD CONSTRAINT "search_index_workspace_id_fkey"
+    FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "search_index_workspace_id_idx"
+  ON "search_index" ("workspace_id");

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1758104600459,
       "tag": "0017_fix_forlandeivan_workspace",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1758104601459,
+      "tag": "0018_workspace_collections_and_page_ownership",
+      "breakpoints": true
     }
   ]
 }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -123,6 +123,15 @@ export const workspaceMembers = pgTable(
   }),
 );
 
+export const workspaceVectorCollections = pgTable("workspace_vector_collections", {
+  collectionName: text("collection_name").primaryKey(),
+  workspaceId: varchar("workspace_id")
+    .notNull()
+    .references(() => workspaces.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
+  updatedAt: timestamp("updated_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
+});
+
 export const personalApiTokens = pgTable("personal_api_tokens", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   userId: varchar("user_id")
@@ -300,6 +309,9 @@ export const pages = pgTable("pages", {
   searchVectorCombined: tsvector("search_vector_combined"), // combined tsvector with weights
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
   updatedAt: timestamp("updated_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
+  workspaceId: varchar("workspace_id")
+    .notNull()
+    .references(() => workspaces.id, { onDelete: "cascade" }),
 });
 
 // Search index for fast text search
@@ -311,6 +323,9 @@ export const searchIndex = pgTable("search_index", {
   position: integer("position").notNull(),
   relevance: doublePrecision("relevance"), // Add missing relevance column
   createdAt: timestamp("created_at").default(sql`CURRENT_TIMESTAMP`).notNull(),
+  workspaceId: varchar("workspace_id")
+    .notNull()
+    .references(() => workspaces.id, { onDelete: "cascade" }),
 });
 
 export const embeddingProviders = pgTable("embedding_providers", {
@@ -401,11 +416,13 @@ export const insertPageSchema = createInsertSchema(pages).omit({
   id: true,
   createdAt: true,
   updatedAt: true,
+  workspaceId: true,
 });
 
 export const insertSearchIndexSchema = createInsertSchema(searchIndex).omit({
   id: true,
   createdAt: true,
+  workspaceId: true,
 });
 
 export const insertEmbeddingProviderSchema = createInsertSchema(embeddingProviders)
@@ -546,6 +563,7 @@ export type Workspace = typeof workspaces.$inferSelect;
 export type WorkspaceInsert = typeof workspaces.$inferInsert;
 export type WorkspaceMember = typeof workspaceMembers.$inferSelect;
 export type WorkspaceMemberInsert = typeof workspaceMembers.$inferInsert;
+export type WorkspaceVectorCollection = typeof workspaceVectorCollections.$inferSelect;
 export type AuthProvider = typeof authProviders.$inferSelect;
 export type AuthProviderInsert = typeof authProviders.$inferInsert;
 export type EmbeddingProvider = typeof embeddingProviders.$inferSelect;


### PR DESCRIPTION
## Summary
- добавить миграцию, создающую таблицу привязки коллекций к рабочим пространствам и заполняющую владельца forlandeivan вместе с обновлением страниц и поисковых индексов
- расширить схему данных и хранилище: новые столбцы workspace_id у страниц и search_index, а также методы для учёта владельцев Qdrant коллекций
- ограничить API Qdrant коллекций текущим рабочим пространством и назначать владельца при создании/векторизации коллекций

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e6711136e88326bb9d4f81aab1a5d6